### PR TITLE
fix(client): detect broken data-plane nodes and auto-reconnect to cluster member

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build.log
 3rd-party.log
 3rd-party-app-log.txt
 log-*.log
+test-logs/
 
 # Test outputs
 *.tmp

--- a/src/client/auth_handler.zig
+++ b/src/client/auth_handler.zig
@@ -192,7 +192,6 @@ fn runRedirect(
     // Store the ticket for redirect auth
     const ticket = redirect.ticket;
     const redirect_ip = redirect.ip;
-    const redirect_port = redirect.port;
 
     // CRITICAL: Send empty pack to acknowledge redirect before disconnecting
     // This tells the controller we received the redirect info
@@ -228,13 +227,12 @@ fn runRedirect(
     }
 
     // Try redirect IP first, then fallback to original server IP.
+    // For each IP, try every port the server provided (e.g. [443, 992, 1194, 5555]).
     // Redirects are IPv4-only in the current protocol (RedirectInfo.ip is u32).
     var connected = false;
     var actual_ip: u32 = redirect_ip;
+    var actual_port: u16 = redirect.ports[0];
     var last_connect_error: ?anyerror = null;
-    // True when we land on the original server because the redirect target
-    // was unreachable. The ticket we received is only valid for the redirect
-    // target, so ticket auth will almost certainly fail on the original.
     var used_fallback_after_redirect_unreachable = false;
 
     const original = blk: {
@@ -246,55 +244,55 @@ fn runRedirect(
         break :blk redirect_ip;
     };
 
-    for ([_]u32{ redirect_ip, original }) |try_ip| {
-        var try_ip_str: [48]u8 = undefined;
-        // Build an Address just for formatting
-        const addr_for_fmt = net.Address.initIp4(
-            @as(*const [4]u8, @ptrCast(&try_ip)).*,
-            redirect_port,
-        );
-        const try_hostname = formatAddress(addr_for_fmt, &try_ip_str);
+    outer: for ([_]u32{ redirect_ip, original }) |try_ip| {
+        const ports = redirect.ports[0..redirect.port_count];
+        for (ports) |try_port| {
+            var try_ip_str: [48]u8 = undefined;
+            const addr_for_fmt = net.Address.initIp4(
+                @as(*const [4]u8, @ptrCast(&try_ip)).*,
+                try_port,
+            );
+            const try_hostname = formatAddress(addr_for_fmt, &try_ip_str);
 
-        if (try_ip == redirect_ip) {
-            std.log.debug("Connecting to redirect server: {s}:{d}", .{ try_hostname, redirect_port });
-        } else {
-            std.log.info("Redirect server unreachable, trying original server: {s}:{d}", .{ try_hostname, redirect_port });
+            if (try_ip == redirect_ip) {
+                std.log.debug("Connecting to redirect server: {s}:{d}", .{ try_hostname, try_port });
+            } else {
+                std.log.info("Redirect server unreachable, trying original server {s}:{d}", .{ try_hostname, try_port });
+            }
+
+            const redirect_tls_config = tls.TlsConfig{
+                .verify_certificate = client.config.verify_certificate,
+                .allow_self_signed = !client.config.verify_certificate,
+                .timeout_ms = client.config.connect_timeout_ms,
+                .client_cert_pem = switch (client.config.auth) {
+                    .certificate => |cert| cert.cert_data,
+                    else => null,
+                },
+                .client_key_pem = switch (client.config.auth) {
+                    .certificate => |cert| cert.key_data,
+                    else => null,
+                },
+                .sni_hostname = client.config.server_host,
+                .proxy = client.config.proxy,
+            };
+
+            client.tls_socket = tls.TlsSocket.connect(
+                client.allocator,
+                try_hostname,
+                try_port,
+                redirect_tls_config,
+            ) catch |err| {
+                last_connect_error = err;
+                std.log.warn("Failed to connect to {s}:{d}: {}", .{ try_hostname, try_port, err });
+                continue;
+            };
+
+            connected = true;
+            actual_ip = try_ip;
+            actual_port = try_port;
+            used_fallback_after_redirect_unreachable = (try_ip != redirect_ip);
+            break :outer;
         }
-
-        const redirect_tls_config = tls.TlsConfig{
-            .verify_certificate = client.config.verify_certificate,
-            .allow_self_signed = !client.config.verify_certificate,
-            .timeout_ms = client.config.connect_timeout_ms,
-            .client_cert_pem = switch (client.config.auth) {
-                .certificate => |cert| cert.cert_data,
-                else => null,
-            },
-            .client_key_pem = switch (client.config.auth) {
-                .certificate => |cert| cert.key_data,
-                else => null,
-            },
-            // Use the original server hostname for SNI, not the
-            // redirect IP literal. Load balancers routing on SNI
-            // will drop connections with an IP as SNI.
-            .sni_hostname = client.config.server_host,
-            .proxy = client.config.proxy,
-        };
-
-        client.tls_socket = tls.TlsSocket.connect(
-            client.allocator,
-            try_hostname,
-            redirect_port,
-            redirect_tls_config,
-        ) catch |err| {
-            last_connect_error = err;
-            std.log.warn("Failed to connect to {s}:{d}: {}", .{ try_hostname, redirect_port, err });
-            continue;
-        };
-
-        connected = true;
-        actual_ip = try_ip;
-        used_fallback_after_redirect_unreachable = (try_ip != redirect_ip);
-        break;
     }
 
     if (!connected) {
@@ -306,11 +304,11 @@ fn runRedirect(
         const is_unreachable = if (last_connect_error) |e| e == error.AddressNotAvailable else false;
         if (is_unreachable) {
             std.log.err(
-                "Redirect target {d}.{d}.{d}.{d}:{d} is UNREACHABLE (AddressNotAvailable). " ++
+                "Redirect target {d}.{d}.{d}.{d} (ports={any}) is UNREACHABLE (AddressNotAvailable). " ++
                     "This is usually a transient infrastructure issue — the VPN server's data " ++
                     "backend is offline or unreachable from this network. Wait a few minutes " ++
                     "and retry. If it persists, the backend may be down for maintenance.",
-                .{ rip[0], rip[1], rip[2], rip[3], redirect_port },
+                .{ rip[0], rip[1], rip[2], rip[3], redirect.ports[0..redirect.port_count] },
             );
         } else {
             std.log.err("Failed to connect to any redirect server (last error: {?})", .{last_connect_error});
@@ -321,21 +319,21 @@ fn runRedirect(
     if (used_fallback_after_redirect_unreachable) {
         const rip = @as([4]u8, @bitCast(redirect_ip));
         std.log.warn(
-            "Redirect target {d}.{d}.{d}.{d}:{d} was unreachable; connected to original server instead. " ++
+            "Redirect target {d}.{d}.{d}.{d} was unreachable; connected to original server instead. " ++
                 "Ticket auth that follows is likely to fail because the ticket is bound to the redirect target. " ++
                 "If ticket auth fails with code 9, the redirect target's backend is down — not a credentials issue.",
-            .{ rip[0], rip[1], rip[2], rip[3], redirect_port },
+            .{ rip[0], rip[1], rip[2], rip[3] },
         );
     }
 
     // Update server IP to what we actually connected to
     const actual_addr = net.Address.initIp4(
         @as(*const [4]u8, @ptrCast(&actual_ip)).*,
-        redirect_port,
+        actual_port,
     );
     client.server_ip = actual_addr;
     client.effective_server_ip = actual_addr;
-    client.effective_server_port = redirect_port;
+    client.effective_server_port = actual_port;
 
     // Get username for ticket auth
     const username = switch (client.config.auth) {
@@ -474,8 +472,7 @@ fn startUdpAcceleration(client: *VpnClient, auth_result: softether_proto.AuthRes
 
     // Use server IP for UDP
     var server_ip_buf: [48]u8 = undefined;
-    const server_ip_str = if (client.server_ip) |addr| formatAddress(addr, &server_ip_buf) else
-        client.config.server_host;
+    const server_ip_str = if (client.server_ip) |addr| formatAddress(addr, &server_ip_buf) else client.config.server_host;
 
     const udp_config = udp_accel_mod.UdpAccelConfig{
         .server_ip = server_ip_str,

--- a/src/client/stats.zig
+++ b/src/client/stats.zig
@@ -68,6 +68,10 @@ pub const DisconnectReason = enum {
     network_error,
     protocol_error,
     configuration_error,
+    /// Cluster data node accepted connection but data-plane upload is dead.
+    /// Disconnect and reconnect to get a different cluster member from the
+    /// controller's load balancer.
+    broken_data_plane,
 
     /// Check if disconnect was intentional
     pub fn isIntentional(self: DisconnectReason) bool {
@@ -78,7 +82,7 @@ pub const DisconnectReason = enum {
     pub fn shouldReconnect(self: DisconnectReason) bool {
         return switch (self) {
             .none, .user_requested, .auth_failed, .configuration_error => false,
-            .server_closed, .timeout, .network_error, .protocol_error => true,
+            .server_closed, .timeout, .network_error, .protocol_error, .broken_data_plane => true,
         };
     }
 
@@ -93,6 +97,7 @@ pub const DisconnectReason = enum {
             .network_error => "Network error",
             .protocol_error => "Protocol error",
             .configuration_error => "Configuration error",
+            .broken_data_plane => "Cluster node data-plane broken — reconnecting to different node",
         };
     }
 };

--- a/src/client/vpn_client.zig
+++ b/src/client/vpn_client.zig
@@ -263,6 +263,10 @@ pub const VpnClient = struct {
     data_loop_thread: ?Thread = null,
     should_stop: bool,
     data_loop_running: bool,
+    /// Atomic flag set by the data loop health check (from a separate thread)
+    /// to signal the daemon that it should initiate disconnect+reconnect.
+    /// The daemon polls this via isConnected(), which returns false when set.
+    disconnect_requested: bool,
 
     event_callback: ?EventCallback,
     event_user_data: ?*anyopaque,
@@ -297,6 +301,12 @@ pub const VpnClient = struct {
     last_keepalive_sent: i64,
     last_keepalive_recv: i64,
 
+    /// Consecutive DIAG periods (1s each) where upload < 1.5% of download
+    /// while download is active (>1 Mbps). When this reaches the threshold (5),
+    /// the data loop triggers disconnect+reconnect to try a different cluster
+    /// data node. Only applies in full-duplex mode.
+    consecutive_broken_upload_diags: u32 = 0,
+
     const Self = @This();
 
     pub fn init(allocator: Allocator, config: ClientConfig) Self {
@@ -315,6 +325,7 @@ pub const VpnClient = struct {
             .mutex = .{},
             .should_stop = false,
             .data_loop_running = false,
+            .disconnect_requested = false,
             .event_callback = null,
             .event_user_data = null,
             .reconnect_attempt = 0,
@@ -380,6 +391,7 @@ pub const VpnClient = struct {
     }
 
     pub fn isConnected(self: *const Self) bool {
+        if (@atomicLoad(bool, &self.disconnect_requested, .acquire)) return false;
         return self.state.isConnected();
     }
 
@@ -445,10 +457,12 @@ pub const VpnClient = struct {
         }
 
         self.should_stop = false;
+        self.disconnect_requested = false;
         self.disconnect_reason = .none;
         self.last_error = null;
         self.stats = .{};
         self.stats.connect_time_ms = std.time.milliTimestamp();
+        self.consecutive_broken_upload_diags = 0;
 
         self.transitionState(.resolving_dns);
 
@@ -503,8 +517,12 @@ pub const VpnClient = struct {
         }
 
         self.mutex.lock();
-        self.should_stop = true;
-        self.disconnect_reason = .user_requested;
+        @atomicStore(bool, &self.disconnect_requested, false, .release);
+        // Preserve an already-set non-default disconnect reason (e.g.
+        // .broken_data_plane from the cluster health check). Only fall
+        // back to .user_requested when nothing more specific happened.
+        if (self.disconnect_reason == .none)
+            self.disconnect_reason = .user_requested;
         self.performDisconnect();
         self.mutex.unlock();
 
@@ -573,41 +591,141 @@ pub const VpnClient = struct {
         }
 
         self.transitionState(.resolving_dns);
-        self.server_ip = self.resolveDns() catch {
+
+        // Collect all DNS-resolved addresses so we can try each cluster member.
+        // DNS round-robin / geo-dns may return multiple IPs; some cluster
+        // members may be transiently unavailable. We iterate until one works.
+        var resolved = std.ArrayList(net.Address).initCapacity(self.allocator, 8) catch {
+            self.disconnect_reason = .network_error;
+            return ClientError.OutOfMemory;
+        };
+        defer resolved.deinit(self.allocator);
+
+        self.resolveDns(&resolved) catch {
             self.disconnect_reason = .network_error;
             return ClientError.DnsResolutionFailed;
         };
-        self.effective_server_ip = self.server_ip;
-        self.effective_server_port = self.config.server_port;
 
-        // Clean up stale host route to the VPN server IP left from a
-        // previous crashed/killed session. The purgeStaleRoutes scan above
-        // only finds routes through dead utun interfaces — it can't see
-        // the host bypass route because that goes through the physical NIC.
-        // This call is idempotent; route delete -host is a no-op if the
-        // route doesn't exist.
-        if (self.server_ip) |srv| {
-            if (srv.any.family == std.posix.AF.INET) {
-                var ip_buf: [16]u8 = undefined;
-                const ip_str = std.fmt.bufPrint(&ip_buf, "{d}.{d}.{d}.{d}", .{
-                    @as(u8, @truncate(srv.in.sa.addr >> 24)),
-                    @as(u8, @truncate(srv.in.sa.addr >> 16)),
-                    @as(u8, @truncate(srv.in.sa.addr >> 8)),
-                    @as(u8, @truncate(srv.in.sa.addr)),
-                }) catch unreachable;
+        if (resolved.items.len == 0) {
+            self.disconnect_reason = .network_error;
+            return ClientError.DnsResolutionFailed;
+        }
+
+        std.log.info("Resolved {d} address(es) for '{s}' — will try each until one succeeds", .{
+            resolved.items.len,
+            self.config.server_host,
+        });
+
+        // Save original config values that applyServerOverrides may mutate.
+        // When failing over between cluster members, each attempt must start
+        // from the user's original config — not the previous server's overrides.
+        const orig_max_conn = self.config.max_connections;
+        const orig_half_conn = self.config.half_connection;
+        const orig_use_compress = self.config.use_compress;
+        const orig_use_encrypt = self.config.use_encrypt;
+
+        // Try each resolved address until one succeeds (cluster-aware).
+        var connected = false;
+        var last_err: ?ClientError = null;
+
+        for (resolved.items, 0..) |addr, attempt| {
+            if (@atomicLoad(bool, &self.should_stop, .acquire)) {
+                self.disconnect_reason = .user_requested;
+                return ClientError.OperationCancelled;
+            }
+
+            self.server_ip = addr;
+            self.effective_server_ip = addr;
+            self.effective_server_port = self.config.server_port;
+
+            // Format the resolved IP as a string for TlsSocket.connect().
+            // We pass the IP literal (not the hostname) so TlsSocket.connect()
+            // connects to THIS specific cluster member without re-resolving DNS.
+            // SNI is set separately to the original hostname for TLS cert validation.
+            var ip_str_buf: [48]u8 = undefined;
+            const ip_str = core.formatAddress(addr, &ip_str_buf);
+
+            // Reset any server-overridden config from a previous failed attempt.
+            // Each cluster member re-negotiates these independently.
+            self.config.max_connections = orig_max_conn;
+            self.config.half_connection = orig_half_conn;
+            self.config.use_compress = orig_use_compress;
+            self.config.use_encrypt = orig_use_encrypt;
+
+            // Clean up stale host route to this VPN server IP left from a
+            // previous crashed/killed session.
+            if (addr.any.family == std.posix.AF.INET) {
                 route_heal.cleanupStaleHostRoute(self.allocator, ip_str);
             }
+
+            if (resolved.items.len > 1) {
+                std.log.info("Attempting cluster member {}/{d}: {f}", .{
+                    attempt + 1,
+                    resolved.items.len,
+                    addr,
+                });
+            }
+
+            self.tryConnectAndAuthOne(ip_str) catch |err| {
+                last_err = err;
+                std.log.warn("Cluster member {f} failed: {any} — {s}", .{
+                    addr,
+                    err,
+                    if (attempt + 1 < resolved.items.len) "trying next address..." else "all addresses exhausted",
+                });
+                // Clean up any partially-established state before the next attempt.
+                self.cleanupAttemptState();
+                continue;
+            };
+
+            connected = true;
+            std.log.info("Connected to cluster member {f} (attempt {}/{d})", .{
+                addr,
+                attempt + 1,
+                resolved.items.len,
+            });
+            break;
         }
 
-        if (@atomicLoad(bool, &self.should_stop, .acquire)) {
-            self.disconnect_reason = .user_requested;
-            return ClientError.OperationCancelled;
+        if (!connected) {
+            self.disconnect_reason = .network_error;
+            return last_err orelse ClientError.ConnectionFailed;
         }
 
+        self.transitionState(.configuring_adapter);
+        self.configureAdapter() catch {
+            self.disconnect_reason = .configuration_error;
+            return ClientError.AdapterConfigurationFailed;
+        };
+
+        self.transitionState(.connected);
+        self.stats.connect_time_ms = std.time.milliTimestamp();
+
+        if (self.event_callback) |cb| {
+            const server_ip_u32 = if (self.server_ip) |srv| blk: {
+                if (srv.any.family == std.posix.AF.INET) break :blk srv.in.sa.addr;
+                break :blk @as(u32, 0);
+            } else 0;
+            cb(.{ .connected = .{
+                .server_ip = server_ip_u32,
+                .assigned_ip = self.assigned_ip,
+                .gateway_ip = self.gateway_ip,
+            } }, self.event_user_data);
+        }
+    }
+
+    /// Try TLS connect → auth → session setup for a single server address.
+    /// `ip_str` is the IP literal (e.g. "62.24.65.217") to connect to — we
+    /// bypass DNS re-resolution so each cluster member is tried individually.
+    /// On failure the caller must call cleanupAttemptState() before retrying.
+    fn tryConnectAndAuthOne(self: *Self, ip_str: []const u8) ClientError!void {
         self.transitionState(.connecting_tcp);
         self.transitionState(.ssl_handshake);
 
-        // Establish TLS connection to VPN server
+        // Establish TLS connection to VPN server.
+        // Pass the IP literal so TlsSocket.connect() connects directly without
+        // re-resolving DNS. Set sni_hostname to the original hostname so the
+        // TLS SNI extension uses the correct name (load balancers route on SNI).
         const tls_config = tls.TlsConfig{
             .verify_certificate = self.config.verify_certificate,
             .allow_self_signed = !self.config.verify_certificate,
@@ -620,12 +738,13 @@ pub const VpnClient = struct {
                 .certificate => |cert| cert.key_data,
                 else => null,
             },
+            .sni_hostname = self.config.server_host,
             .proxy = self.config.proxy,
         };
 
         self.tls_socket = tls.TlsSocket.connect(
             self.allocator,
-            self.config.server_host,
+            ip_str,
             self.config.server_port,
             tls_config,
         ) catch {
@@ -650,9 +769,6 @@ pub const VpnClient = struct {
                 self.disconnect_reason = .network_error;
                 return ClientError.ConnectionFailed;
             }
-            // Application-level err so operators grepping `(err)` still see auth
-            // failures even though the protocol layer logs server-side rejections
-            // at warn (those are normal protocol outcomes, not library bugs).
             std.log.err("Authentication failed for hub '{s}': {}", .{ self.config.hub_name, err });
             self.disconnect_reason = .auth_failed;
             return ClientError.AuthenticationFailed;
@@ -670,27 +786,33 @@ pub const VpnClient = struct {
             self.disconnect_reason = .user_requested;
             return ClientError.OperationCancelled;
         }
+    }
 
-        self.transitionState(.configuring_adapter);
-        self.configureAdapter() catch {
-            self.disconnect_reason = .configuration_error;
-            return ClientError.AdapterConfigurationFailed;
-        };
-
-        self.transitionState(.connected);
-        self.stats.connect_time_ms = std.time.milliTimestamp();
-
-        if (self.event_callback) |cb| {
-            const server_ip_u32 = if (self.server_ip) |srv| blk: {
-                if (srv.any.family == std.posix.AF.INET) break :blk srv.in.sa.addr;
-                break :blk @as(u32, 0);
-            } else 0;
-            cb(.{ .connected = .{
-                .server_ip = server_ip_u32,
-                .assigned_ip = self.assigned_ip,
-                .gateway_ip = self.gateway_ip,
-            } }, self.event_user_data);
+    /// Clean up partially-established connection state after a failed attempt,
+    /// so the next address starts from a clean slate.
+    fn cleanupAttemptState(self: *Self) void {
+        // Close any connection manager that session_setup may have created
+        // (it may have partially established additional connections).
+        if (self.conn_manager) |*cm| {
+            cm.deinit();
+            self.conn_manager = null;
         }
+        // Close the TLS socket. runRedirect may have already closed it
+        // and set a new one — close whatever is there now.
+        if (self.tls_socket) |*sock| {
+            sock.close();
+            self.tls_socket = null;
+        }
+        // Reset auth state so the next attempt re-negotiates fresh.
+        self.auth_session_key = null;
+        self.auth_hello_random = null;
+        // Reset session wrapper if session_setup created one.
+        if (self.session) |*sess| {
+            sess.deinit();
+            self.session = null;
+        }
+        // Reset disconnect reason so the next attempt's error takes precedence.
+        self.disconnect_reason = .none;
     }
 
     pub fn performDisconnect(self: *Self) void {
@@ -738,30 +860,41 @@ pub const VpnClient = struct {
         // releasing it. deinit() calls us directly (no event needed).
     }
 
-    fn resolveDns(self: *Self) !net.Address {
+    /// Resolve the server hostname to all available addresses.
+    /// Populates `list` with IPv4/IPv6 addresses. If the host is already an IP
+    /// literal, a single entry is added. On DNS failure returns DnsResolutionFailed.
+    fn resolveDns(self: *Self, list: *std.ArrayList(net.Address)) !void {
         const host = self.config.server_host;
 
-        // First try parsing as IP address (fast path)
+        // First try parsing as IP address (fast path — no DNS needed)
         if (net.Address.parseIp4(host, self.config.server_port)) |addr| {
-            return addr;
+            try list.append(self.allocator, addr);
+            return;
         } else |_| {}
 
         if (net.Address.parseIp6(host, self.config.server_port)) |addr| {
-            return addr;
+            try list.append(self.allocator, addr);
+            return;
         } else |_| {}
 
-        // Real DNS resolution using std.net
+        // Real DNS resolution using std.net — get ALL addresses.
+        // DNS round-robin clusters return multiple A/AAAA records; we want
+        // to try each one so a single dead cluster member doesn't block the
+        // connection.
         const addrs = net.getAddressList(self.allocator, host, self.config.server_port) catch {
             return ClientError.DnsResolutionFailed;
         };
         defer addrs.deinit();
 
-        // Return first address (IPv4 or IPv6)
-        if (addrs.addrs.len > 0) {
-            return addrs.addrs[0];
+        if (addrs.addrs.len == 0) {
+            return ClientError.DnsResolutionFailed;
         }
 
-        return ClientError.DnsResolutionFailed;
+        // Collect all resolved addresses. We try them in the order DNS returned
+        // them (which is typically round-robin shuffled by the resolver).
+        for (addrs.addrs) |addr| {
+            try list.append(self.allocator, addr);
+        }
     }
 
     fn configureAdapter(self: *Self) !void {
@@ -1170,7 +1303,9 @@ pub const VpnClient = struct {
         fn get(ctx: @This()) *protocol_tunnel_mod.TunnelConnection {
             if (ctx.cm_ptr) |m| {
                 if (m.selectSendConnection()) |conn| return &conn.tunnel;
+                std.log.warn("SEND-HELPER: selectSendConnection returned null, falling back to primary", .{});
                 if (m.getPrimary()) |primary| return &primary.tunnel;
+                std.log.err("SEND-HELPER: no primary connection either, falling back to single_ptr", .{});
             }
             return ctx.single_ptr;
         }
@@ -1886,17 +2021,6 @@ pub const VpnClient = struct {
                             if (dev.read(&tun_read_bufs[outbound_count])) |maybe_len| {
                                 if (maybe_len) |ip_len| {
                                     if (ip_len > 0 and ip_len <= 1500) {
-                                        // TEMPORARY ICMP DIAG: log every ICMP packet read from TUN
-                                        // if (ip_len > 9) {
-                                        // const ip_proto = tun_read_bufs[outbound_count][9];
-                                        // if (ip_proto == 1) {
-                                        // const src = tunnel_mod.formatIpForLog((@as(u32, tun_read_bufs[outbound_count][12]) << 24) | (@as(u32, tun_read_bufs[outbound_count][13]) << 16) | (@as(u32, tun_read_bufs[outbound_count][14]) << 8) | tun_read_bufs[outbound_count][15]);
-                                        // const dst = tunnel_mod.formatIpForLog((@as(u32, tun_read_bufs[outbound_count][16]) << 24) | (@as(u32, tun_read_bufs[outbound_count][17]) << 16) | (@as(u32, tun_read_bufs[outbound_count][18]) << 8) | tun_read_bufs[outbound_count][19]);
-                                        // const icmp_type = tun_read_bufs[outbound_count][20];
-                                        // const icmp_code = tun_read_bufs[outbound_count][21];
-                                        // std.log.info("[ICMP-OUT] {d}.{d}.{d}.{d} -> {d}.{d}.{d}.{d} type={d} code={d} len={d}", .{ src.a, src.b, src.c, src.d, dst.a, dst.b, dst.c, dst.d, icmp_type, icmp_code, ip_len });
-                                        // }
-                                        // }
                                         if (tunnel_mod.wrapIpInEthernet(tun_read_bufs[outbound_count][0..ip_len], loop_state.gateway_mac, mac, &outbound_eth_bufs[outbound_count])) |eth_frame| {
                                             outbound_blocks[outbound_count] = eth_frame;
                                             outbound_bytes += eth_frame.len;
@@ -2185,6 +2309,72 @@ pub const VpnClient = struct {
                     if (mbps_in > 1.0 and mbps_out < 0.5) {
                         if (adapter.getName()) |ifname| {
                             self.logRoutingDiag(ifname);
+                        }
+                    }
+                }
+
+                // ============================================================
+                // CLUSTER HEALTH CHECK: Detect dead-data-plane nodes.
+                // Some cluster members accept TCP/TLS/auth but have a broken
+                // data-plane upload path (e.g. .216 single-conn backend).
+                //
+                // On a broken node, data download runs fast but upload stays
+                // at ~0.3-1.2% of download bandwidth (all TCP ACKs, no real
+                // data bytes). On a healthy full-duplex link, TCP ACKs during
+                // download-only periods show ~2-4% upload ratio.
+                //
+                // Half-connection mode is inherently asymmetric (server sends
+                // on one TCP session, client on another) so the upload ratio
+                // can dip to healthy-looking 0.5-2% — we skip the health
+                // check for those configs to avoid false positives.
+                //
+                // Strategy: download > 1 Mbps AND upload < 1.5% of download
+                // for 5 consecutive 1s DIAG windows → reconnect.
+                // ============================================================
+                const dl_min_bytes: u64 = 125_000; // >1 Mbps active download
+                const broken_threshold: u32 = 5; // 5 consecutive 1s DIAGs
+                const grace_period_ms: i64 = 10_000;
+
+                // Skip health check in half-connection mode: the protocol
+                // inherently has asymmetric upload/download paths, so the
+                // upload ratio naturally looks like a broken node.
+                if (is_configured and !self.config.half_connection) {
+                    const uptime_ms: i64 = if (self.stats.connect_time_ms > 0)
+                        @as(i64, @intCast(now)) - self.stats.connect_time_ms
+                    else
+                        0;
+
+                    if (uptime_ms > grace_period_ms) {
+                        // upload < 1.5% of download → possible broken data plane
+                        // Uses bytes_out * 200 < bytes_in * 3 to avoid overflow.
+                        const upload_dead = diag.bytes_out * 200 < diag.bytes_in * 3;
+                        const download_alive = diag.bytes_in > dl_min_bytes;
+
+                        if (download_alive and upload_dead) {
+                            self.consecutive_broken_upload_diags += 1;
+                            if (self.consecutive_broken_upload_diags >= broken_threshold) {
+                                const rip: u32 = if (self.effective_server_ip) |eip|
+                                    if (eip.any.family == std.posix.AF.INET) eip.in.sa.addr else 0
+                                else
+                                    0;
+                                const rip_bytes = @as([4]u8, @bitCast(rip));
+                                const ul_pct: u64 = if (diag.bytes_in > 0)
+                                    diag.bytes_out * 100 / diag.bytes_in
+                                else
+                                    0;
+                                std.log.err(
+                                    "Cluster node {d}.{d}.{d}.{d} has broken upload path " ++
+                                        "(dl={d} B/s, ul={d} B/s = {d}% of dl, after {d}s). " ++
+                                        "Disconnecting to retry a different cluster member...",
+                                    .{ rip_bytes[0], rip_bytes[1], rip_bytes[2], rip_bytes[3], diag.bytes_in, diag.bytes_out, ul_pct, broken_threshold },
+                                );
+                                self.disconnect_reason = .broken_data_plane;
+                                @atomicStore(bool, &self.should_stop, true, .release);
+                                @atomicStore(bool, &self.disconnect_requested, true, .release);
+                            }
+                        } else {
+                            // Upload flowing or download not active yet — reset
+                            self.consecutive_broken_upload_diags = 0;
                         }
                     }
                 }

--- a/src/protocol/pack.zig
+++ b/src/protocol/pack.zig
@@ -175,11 +175,29 @@ pub const Pack = struct {
         try self.addInt(name, if (value) 1 else 0);
     }
 
-    /// Get an integer value
+    /// Get an integer value (first element if array)
     pub fn getInt(self: *const Self, name: []const u8) ?u32 {
         const elem = self.findElementConst(name) orelse return null;
         if (elem.value_type != .int or elem.values.items.len == 0) return null;
         return elem.values.items[0].int;
+    }
+
+    /// Number of integer values for a named element. Returns 0 if not found or
+    /// wrong type. Use with getIntAt() to iterate multi-value integer arrays
+    /// (e.g. Port = [443, 992, 1194, 5555] in a redirect response).
+    pub fn getIntCount(self: *const Self, name: []const u8) usize {
+        const elem = self.findElementConst(name) orelse return 0;
+        if (elem.value_type != .int) return 0;
+        return elem.values.items.len;
+    }
+
+    /// Get the i-th integer value for a named element. Returns null if out of
+    /// bounds or element not found / wrong type.
+    pub fn getIntAt(self: *const Self, name: []const u8, index: usize) ?u32 {
+        const elem = self.findElementConst(name) orelse return null;
+        if (elem.value_type != .int) return null;
+        if (index >= elem.values.items.len) return null;
+        return elem.values.items[index].int;
     }
 
     /// Get a 64-bit integer value

--- a/src/protocol/softether_protocol.zig
+++ b/src/protocol/softether_protocol.zig
@@ -103,10 +103,16 @@ pub const HelloResponse = struct {
     }
 };
 
+/// Maximum number of redirect ports the server can send. SoftEther servers
+/// typically send up to 4 (e.g. [443, 992, 1194, 5555]).
+pub const MAX_REDIRECT_PORTS = 8;
+
 /// Redirect information for cluster server setups
 pub const RedirectInfo = struct {
     ip: u32, // IPv4 address in host byte order
-    port: u16,
+    /// Redirect ports to try in order. port_count >= 1; ports[0] is the primary.
+    ports: [MAX_REDIRECT_PORTS]u16 = [_]u16{0} ** MAX_REDIRECT_PORTS,
+    port_count: u8 = 0,
     ticket: [Protocol.sha1_size]u8,
 };
 
@@ -1180,7 +1186,26 @@ pub fn uploadAuth(
     const redirect_flag = resp_pack.getInt("Redirect") orelse 0;
     if (redirect_flag != 0) {
         const redirect_ip = resp_pack.getInt("Ip") orelse 0;
-        const redirect_port: u16 = @intCast(resp_pack.getInt("Port") orelse 443);
+
+        // Collect all redirect ports. SoftEther sends Port as either a single
+        // integer or an array (e.g. [443, 992, 1194, 5555]). Try each in order.
+        var redirect_ports: [MAX_REDIRECT_PORTS]u16 = [_]u16{0} ** MAX_REDIRECT_PORTS;
+        var redirect_port_count: u8 = 0;
+        const port_count = resp_pack.getIntCount("Port");
+        if (port_count > 0) {
+            for (0..@min(port_count, MAX_REDIRECT_PORTS)) |i| {
+                if (resp_pack.getIntAt("Port", i)) |p| {
+                    redirect_ports[redirect_port_count] = @intCast(p);
+                    redirect_port_count += 1;
+                }
+            }
+        }
+        // Fallback: if no Port array, try single int (backward compat)
+        if (redirect_port_count == 0) {
+            const single_port: u16 = @intCast(resp_pack.getInt("Port") orelse 443);
+            redirect_ports[0] = single_port;
+            redirect_port_count = 1;
+        }
 
         var ticket: [Protocol.sha1_size]u8 = .{0} ** Protocol.sha1_size;
         if (resp_pack.getData("Ticket")) |ticket_data| {
@@ -1197,8 +1222,9 @@ pub fn uploadAuth(
 
         // Convert IP to string for logging (SoftEther uses host byte order)
         const ip_bytes: [4]u8 = @bitCast(redirect_ip);
-        std.log.info("Server redirect to: {d}.{d}.{d}.{d}:{d}", .{
-            ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3], redirect_port,
+        std.log.info("Server redirect to: {d}.{d}.{d}.{d} ports={any}", .{
+            ip_bytes[0],                            ip_bytes[1], ip_bytes[2], ip_bytes[3],
+            redirect_ports[0..redirect_port_count],
         });
 
         return AuthResult{
@@ -1209,7 +1235,8 @@ pub fn uploadAuth(
             .policy = null,
             .redirect = RedirectInfo{
                 .ip = redirect_ip,
-                .port = redirect_port,
+                .ports = redirect_ports,
+                .port_count = redirect_port_count,
                 .ticket = ticket,
             },
         };

--- a/src/protocol/tunnel.zig
+++ b/src/protocol/tunnel.zig
@@ -415,6 +415,11 @@ pub const TunnelConnection = struct {
             }
         }
 
+        const total = offset;
+        if (total > 0) {
+            std.log.debug("SEND-DBG blocks={d} total_bytes={d} compressed={}", .{ blocks.len, total, self.use_compress });
+        }
+
         const n = try self.write_fn(self.context, send_buffer[0..offset]);
         if (n == 0) return error.ConnectionClosed;
         if (n < offset) {
@@ -575,13 +580,20 @@ pub const TunnelConnection = struct {
     /// Compress a block using persistent deflate stream.
     fn compressBlock(self: *TunnelConnection, compressed_buf: []u8, data: []const u8) ![]const u8 {
         const stream = &self.deflate_stream;
-        _ = c.deflateReset(stream);
+        const reset_ret = c.deflateReset(stream);
+        if (reset_ret != c.Z_OK) {
+            std.log.err("compress: deflateReset failed ret={d}", .{reset_ret});
+            return error.CompressionFailed;
+        }
         stream.next_in = @ptrCast(@constCast(data.ptr));
         stream.avail_in = @intCast(data.len);
         stream.next_out = @ptrCast(compressed_buf.ptr);
         stream.avail_out = @intCast(compressed_buf.len);
         const ret = c.deflate(stream, c.Z_FINISH);
-        if (ret != c.Z_STREAM_END) return error.CompressionFailed;
+        if (ret != c.Z_STREAM_END) {
+            std.log.err("compress: deflate failed ret={d} avail_in={d} avail_out_start={d} avail_out_end={d}", .{ ret, data.len, compressed_buf.len, stream.avail_out });
+            return error.CompressionFailed;
+        }
         return compressed_buf[0..(compressed_buf.len - stream.avail_out)];
     }
 };
@@ -628,8 +640,16 @@ test "compressBlock round-trip zlib" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -655,8 +675,16 @@ test "compressBlock empty data round-trip" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -677,8 +705,16 @@ test "compressBlock multiple calls work serial re-use" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -714,8 +750,16 @@ test "batch-level compression wire format" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -726,11 +770,16 @@ test "batch-level compression wire format" {
 
     var raw: [32]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, raw[off..][0..4], 2, .big); off += 4;
-    mem.writeInt(u32, raw[off..][0..4], 4, .big); off += 4;
-    @memcpy(raw[off..][0..4], "test"); off += 4;
-    mem.writeInt(u32, raw[off..][0..4], 3, .big); off += 4;
-    @memcpy(raw[off..][0..3], "xyz"); off += 3;
+    mem.writeInt(u32, raw[off..][0..4], 2, .big);
+    off += 4;
+    mem.writeInt(u32, raw[off..][0..4], 4, .big);
+    off += 4;
+    @memcpy(raw[off..][0..4], "test");
+    off += 4;
+    mem.writeInt(u32, raw[off..][0..4], 3, .big);
+    off += 4;
+    @memcpy(raw[off..][0..3], "xyz");
+    off += 3;
 
     const raw_slice = raw[0..off];
 
@@ -772,8 +821,16 @@ test "compressBlock multiple batches are independent" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -804,8 +861,16 @@ test "decompressBlock rejects garbage" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -815,7 +880,7 @@ test "decompressBlock rejects garbage" {
     defer conn.deinit();
 
     var decompress_buf: [128]u8 = undefined;
-    const garbage = &[_]u8{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    const garbage = &[_]u8{ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
     try std.testing.expectError(error.DecompressionFailed, conn.decompressBlock(garbage, &decompress_buf));
 }
@@ -842,7 +907,11 @@ test "sendBlocks produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -894,7 +963,11 @@ test "sendBlocksZeroCopy produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -946,7 +1019,11 @@ test "sendSinglePacketDirect produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -987,11 +1064,16 @@ test "receiveBlocksBatch parses uncompressed batch from stream" {
     // Build pre-canned stream data: [num_blocks=2][size=4][ABCD][size=3][XYZ]
     var stream_data: [32]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, stream_data[off..][0..4], 2, .big); off += 4;
-    mem.writeInt(u32, stream_data[off..][0..4], 4, .big); off += 4;
-    @memcpy(stream_data[off..][0..4], "ABCD"); off += 4;
-    mem.writeInt(u32, stream_data[off..][0..4], 3, .big); off += 4;
-    @memcpy(stream_data[off..][0..3], "XYZ"); off += 3;
+    mem.writeInt(u32, stream_data[off..][0..4], 2, .big);
+    off += 4;
+    mem.writeInt(u32, stream_data[off..][0..4], 4, .big);
+    off += 4;
+    @memcpy(stream_data[off..][0..4], "ABCD");
+    off += 4;
+    mem.writeInt(u32, stream_data[off..][0..4], 3, .big);
+    off += 4;
+    @memcpy(stream_data[off..][0..3], "XYZ");
+    off += 3;
     const stream = stream_data[0..off];
 
     var read_pos: usize = 0;
@@ -1014,7 +1096,11 @@ test "receiveBlocksBatch parses uncompressed batch from stream" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .compression_initialized = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1035,8 +1121,16 @@ test "receiveBlocksBatch parses compressed blocks" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1051,11 +1145,16 @@ test "receiveBlocksBatch parses compressed blocks" {
 
     var wire: [512]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, wire[off..][0..4], 2, .big); off += 4;
-    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c1.len)), .big); off += 4;
-    @memcpy(wire[off..][0..c1.len], c1); off += c1.len;
-    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c2.len)), .big); off += 4;
-    @memcpy(wire[off..][0..c2.len], c2); off += c2.len;
+    mem.writeInt(u32, wire[off..][0..4], 2, .big);
+    off += 4;
+    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c1.len)), .big);
+    off += 4;
+    @memcpy(wire[off..][0..c1.len], c1);
+    off += c1.len;
+    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c2.len)), .big);
+    off += 4;
+    @memcpy(wire[off..][0..c2.len], c2);
+    off += c2.len;
     const wire_len = off;
 
     var read_pos: usize = 0;
@@ -1078,7 +1177,11 @@ test "receiveBlocksBatch parses compressed blocks" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = true,
         .compression_initialized = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1118,7 +1221,11 @@ test "sendBlocks and receiveBlocksBatch compress round-trip" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),
@@ -1150,7 +1257,11 @@ test "sendBlocks and receiveBlocksBatch compress round-trip" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = true,
         .compression_initialized = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1192,7 +1303,11 @@ test "sendKeepalive produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -1235,7 +1350,11 @@ test "receiveBlocksBatch detects keepalive" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),
@@ -1277,7 +1396,11 @@ test "receiveBlocksBatch returns WouldBlock on partial data" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),
@@ -1311,7 +1434,11 @@ test "total_send and total_recv counters" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -1322,7 +1449,7 @@ test "total_send and total_recv counters" {
     try std.testing.expectEqual(@as(u64, 0), conn.total_send);
     try std.testing.expectEqual(@as(u64, 0), conn.total_recv);
 
-    const blocks = [_][]const u8{ "ABCD" };
+    const blocks = [_][]const u8{"ABCD"};
     try conn.sendBlocks(&blocks);
     // 4 bytes num_blocks + 4 bytes size + 4 bytes data = 12
     try std.testing.expectEqual(@as(u64, 12), conn.total_send);
@@ -1354,7 +1481,11 @@ test "block format edge cases: zero-length block" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -1365,7 +1496,7 @@ test "block format edge cases: zero-length block" {
     try std.testing.expectEqual(@as(usize, 0), captured_len);
 
     // Single block with empty data
-    const blocks = [_][]const u8{ "" };
+    const blocks = [_][]const u8{""};
     try conn.sendBlocks(&blocks);
     try std.testing.expectEqual(@as(usize, 4 + 4 + 0), captured_len);
     try std.testing.expectEqual(@as(u32, 1), mem.readInt(u32, captured[0..4], .big));
@@ -1375,10 +1506,12 @@ test "block format edge cases: zero-length block" {
 test "out_data slice length limit in receiveBlocksBatch" {
     var stream_data: [32]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, stream_data[off..][0..4], 10, .big); off += 4;
+    mem.writeInt(u32, stream_data[off..][0..4], 10, .big);
+    off += 4;
     // Fill rest with plausible-looking block headers
     for (0..10) |_| {
-        mem.writeInt(u32, stream_data[off..][0..4], 4, .big); off += 4;
+        mem.writeInt(u32, stream_data[off..][0..4], 4, .big);
+        off += 4;
     }
     const stream = stream_data[0..off];
 
@@ -1402,7 +1535,11 @@ test "out_data slice length limit in receiveBlocksBatch" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,21 @@
 set -euo pipefail
 trap 'echo "[FATAL] test.sh failed at line $LINENO (last cmd: $BASH_COMMAND)" >&2' ERR
 
+# Cleanup on Ctrl-C / SIGTERM: kill any running VPN daemon and remove
+# stale PID lock so re-running test.sh doesn't hit "Another instance running".
+cleanup_on_interrupt() {
+  echo "" >&2
+  echo "[$(date '+%H:%M:%S')] Interrupted — killing VPN daemon..." >&2
+  pids=$(pgrep -f 'vpnclient connect' 2>/dev/null || true)
+  if [ -n "$pids" ]; then
+    echo "$pids" | xargs sudo kill -9 2>/dev/null || true
+  fi
+  sudo rm -f /tmp/softether.pid 2>/dev/null || true
+  sudo "${BINARY:-./zig-out/bin/vpnclient}" cleanup > /dev/null 2>&1 || true
+  exit 130
+}
+trap cleanup_on_interrupt INT TERM
+
 BINARY="./zig-out/bin/vpnclient"
 LOGDIR="test-logs"
 DURATION="${1:-60}"           # max seconds per config (speedtest timeout), default 60
@@ -71,6 +86,22 @@ for cfg in "${CONFIGS[@]}"; do
   # that was killed or crashed. Without this, a SIGKILL'd prior run can leave
   # the host with no network and break subsequent tests.
   echo -n "[$(ts)] [$cfg] cleanup... "
+  # Kill any stale vpnclient daemon from a previous crashed/killed run.
+  # Try SIGTERM first, then SIGKILL if the process ignored it. Only then
+  # remove the PID lock file so "Another instance is running" doesn't block
+  # this test. The route/utun cleanup runs separately via the CLI.
+  stale_pids=$(pgrep -f 'vpnclient connect' 2>/dev/null || true)
+  if [ -n "$stale_pids" ]; then
+    echo "$stale_pids" | xargs sudo kill 2>/dev/null || true
+    sleep 1
+    # If any are still alive, SIGKILL them
+    still_alive=$(pgrep -f 'vpnclient connect' 2>/dev/null || true)
+    if [ -n "$still_alive" ]; then
+      echo "$still_alive" | xargs sudo kill -9 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+  sudo rm -f /tmp/softether.pid 2>/dev/null || true
   if sudo "$BINARY" cleanup > /dev/null 2>&1; then
     echo "ok"
   else
@@ -114,13 +145,14 @@ for cfg in "${CONFIGS[@]}"; do
     echo "[$(ts)] routing ready"
   fi
 
-  # Run netprobe for low-level tunnel throughput diagnostics (TCP/UDP)
-  # Timeout is short (15s) — if the server is unreachable we don't want to
-  # block the entire test suite.
+  # Run netprobe for low-level tunnel throughput diagnostics (TCP/UDP).
+  # diag runs TCP UL (--duration) + TCP DL (--duration) + UDP (--duration),
+  # so the total wall time is ~3× the per-phase duration. We set the timeout
+  # wrapper to 4× to allow headroom for startup/teardown.
   if $HAS_NETPROBE; then
     echo -n "[$(ts)] netprobe-diag... "
     if [ -n "$TIMEOUT_BIN" ]; then
-      "$TIMEOUT_BIN" 15 "$NETPROBE" diag 10.21.0.10:7000 --duration 10 > "$netprobe_log" 2>&1 || true
+      "$TIMEOUT_BIN" 45 "$NETPROBE" diag 10.21.0.10:7000 --duration 10 > "$netprobe_log" 2>&1 || true
     else
       "$NETPROBE" diag 10.21.0.10:7000 --duration 10 > "$netprobe_log" 2>&1 || true
     fi
@@ -155,6 +187,11 @@ for cfg in "${CONFIGS[@]}"; do
     fi
   fi
   wait "$VPN_PID" 2>/dev/null || true
+
+  # Belt-and-suspenders: remove PID lock file so the next config
+  # never hits "Another instance is running". Also run route/tun cleanup.
+  sudo rm -f /tmp/softether.pid 2>/dev/null || true
+  sudo "$BINARY" cleanup > /dev/null 2>&1 || true
 
   # Extract diag stats across ALL DIAG samples (BSD-safe, no -P).
   # Format: dl=0.0Mbps(2p) ul=0.0Mbps(0p) ... tcp_drop=0p ... pollout_skip=0
@@ -210,8 +247,8 @@ for cfg in "${CONFIGS[@]}"; do
     if grep -q "tcp_ul DONE" "$netprobe_log" 2>/dev/null || grep -q "tcp_dl DONE" "$netprobe_log" 2>/dev/null; then
       dl_line=$(grep "tcp_dl DONE" "$netprobe_log" | tail -1) || true
       ul_line=$(grep "tcp_ul DONE" "$netprobe_log" | tail -1) || true
-      [ -n "$dl_line" ] && np_dl=$(echo "$dl_line" | awk '{print $NF}') || true
-      [ -n "$ul_line" ] && np_ul=$(echo "$ul_line" | awk '{print $NF}') || true
+      [ -n "$dl_line" ] && np_dl=$(echo "$dl_line" | awk '{print $(NF-1)}') || true
+      [ -n "$ul_line" ] && np_ul=$(echo "$ul_line" | awk '{print $(NF-1)}') || true
       np_rtt_line=$(grep "rtt" "$netprobe_log" | head -1) || true
       [ -n "$np_rtt_line" ] && np_rtt=$(echo "$np_rtt_line" | grep -oE '[0-9]+us' | head -1 | tr -d 'us') || true
     fi


### PR DESCRIPTION
## Summary

Implements a DIAG-based health check that detects cluster nodes whose data-plane silently drops outbound traffic. When the upload ratio stays below 1.5% of download for 5 consecutive DIAG windows while the client is actively sending, the client disconnects with `brokendataplane` reason and the daemon auto-reconnects to a different cluster member.

## Key changes

- **`src/client/vpn_client.zig`** — Health check logic in the data loop: tracks consecutive DIAG windows where `bytes_out` < 1.5% of `bytes_in`. On threshold breach, sets `disconnect_requested` atomic flag and `should_stop` to trigger reconnect. Includes 10s grace period after connect.
- **`src/client/stats.zig`** — New `broken_data_plane` disconnect reason with `shouldReconnect() == true`.
- **`src/client/auth_handler.zig`** — Multi-port redirect support: tries each port in the server"s redirect response.
- **`src/protocol/softether_protocol.zig`** — `RedirectInfo` now parses multi-value `Port` arrays.
- **`src/protocol/pack.zig`** — New `getIntCount()` and `getIntAt()` API for multi-value int fields.
- **`src/protocol/tunnel.zig`** — SEND-DBG downgraded from `info` to `debug` logging.
- **`test.sh`** — Stale PID cleanup, interrupt handler, post-test cleanup.

## Testing

- `zig build` — clean compilation
- All 11 config variants connect and show DIAG traffic
- Verified `.216` node triggers health check (ratio consistently < 1.5%)