### PR TITLE
style: run zig fmt on 5 out-of-compliance source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ log-*.log
 # Test outputs
 *.tmp
 
+# Test output artifacts
+test-logs/
+
 # Compiled binaries
 *.exe
 *.dll

--- a/src/adapter/tun_linux.zig
+++ b/src/adapter/tun_linux.zig
@@ -65,37 +65,37 @@ const IfreqMtu = extern struct {
 /// Linux TUN device structure
 pub const TunLinuxDevice = struct {
     allocator: std.mem.Allocator,
-    
+
     // File descriptor for the TUN device
     fd: ?posix.fd_t,
-    
+
     // Device name (e.g., "tun0")
     device_name: [16]u8,
-    
+
     // MAC address (generated)
     mac_address: [6]u8,
-    
+
     // Configuration
     ipv4_address: u32,
     ipv4_netmask: u32,
     ipv4_gateway: u32,
-    
+
     // Statistics
     stats: TunStats,
-    
+
     // State
     is_open: bool,
     is_configured: bool,
     halt: bool,
-    
+
     connection_start_time: i64,
-    
+
     /// Open a Linux TUN device
     pub fn open(allocator: std.mem.Allocator) TunLinuxError!*TunLinuxDevice {
         if (builtin.os.tag != .linux) {
             return TunLinuxError.NotLinux;
         }
-        
+
         // Open /dev/net/tun
         const fd = posix.open("/dev/net/tun", .{ .ACCMODE = .RDWR }, 0) catch |err| {
             std.log.err("Failed to open /dev/net/tun: {}", .{err});
@@ -105,47 +105,47 @@ pub const TunLinuxDevice = struct {
             return TunLinuxError.OpenFailed;
         };
         errdefer posix.close(fd);
-        
+
         // Set up the TUN device
         var ifr = IfreqFlags{
             .ifrn_name = [_]u8{0} ** 16,
             .ifru_flags = @intCast(IFF_TUN | IFF_NO_PI),
             .padding = [_]u8{0} ** 22,
         };
-        
+
         // Try to create a new TUN device with automatic name
         // Copy "tun%d" to let kernel assign name
         const tun_pattern = "tun%d";
         @memcpy(ifr.ifrn_name[0..tun_pattern.len], tun_pattern);
-        
+
         const ioctl_result = std.c.ioctl(fd, TUNSETIFF, @intFromPtr(&ifr));
         if (ioctl_result < 0) {
             std.log.err("TUNSETIFF ioctl failed: errno={}", .{std.c._errno().*});
             return TunLinuxError.IoctlFailed;
         }
-        
+
         // Extract the device name that was assigned
         var device_name: [16]u8 = ifr.ifrn_name;
-        
+
         // Find the end of the name
         var name_len: usize = 0;
         for (device_name) |c| {
             if (c == 0) break;
             name_len += 1;
         }
-        
+
         std.log.info("Created TUN device: {s}", .{device_name[0..name_len]});
-        
+
         // Generate a random MAC address
         var mac: [6]u8 = undefined;
         std.crypto.random.bytes(&mac);
         mac[0] = (mac[0] & 0xFC) | 0x02; // Set locally administered bit, clear multicast bit
-        
+
         // Allocate device structure
         const device = allocator.create(TunLinuxDevice) catch {
             return TunLinuxError.OpenFailed;
         };
-        
+
         device.* = TunLinuxDevice{
             .allocator = allocator,
             .fd = fd,
@@ -160,10 +160,10 @@ pub const TunLinuxDevice = struct {
             .halt = false,
             .connection_start_time = std.time.milliTimestamp(),
         };
-        
+
         return device;
     }
-    
+
     /// Close the TUN device
     pub fn close(self: *TunLinuxDevice) void {
         if (self.fd) |fd| {
@@ -176,7 +176,7 @@ pub const TunLinuxDevice = struct {
         self.is_configured = false;
         self.allocator.destroy(self);
     }
-    
+
     /// Get device name
     pub fn getName(self: *const TunLinuxDevice) []const u8 {
         var len: usize = 0;
@@ -186,42 +186,42 @@ pub const TunLinuxDevice = struct {
         }
         return self.device_name[0..len];
     }
-    
+
     /// Get MAC address
     pub fn getMac(self: *const TunLinuxDevice) [6]u8 {
         return self.mac_address;
     }
-    
+
     /// Get file descriptor
     pub fn getFd(self: *const TunLinuxDevice) posix.fd_t {
         return self.fd orelse -1;
     }
-    
+
     /// Check if device is open
     pub fn isOpen(self: *const TunLinuxDevice) bool {
         return self.is_open and self.fd != null;
     }
-    
+
     /// Configure temporary IP (for DHCP)
     pub fn configureTemporary(self: *TunLinuxDevice) !void {
         try self.bringInterfaceUp();
     }
-    
+
     /// Configure the TUN device with IP settings
     pub fn configure(self: *TunLinuxDevice, ip: u32, mask: u32, gateway: u32) !void {
         _ = self.fd orelse return TunLinuxError.DeviceNotOpen;
-        
+
         self.ipv4_address = ip;
         self.ipv4_netmask = mask;
         self.ipv4_gateway = gateway;
-        
+
         // IP addresses from DHCP are in network byte order (big-endian)
         // Extract bytes correctly for display
         const ip_b0: u8 = @truncate((ip >> 24) & 0xFF);
         const ip_b1: u8 = @truncate((ip >> 16) & 0xFF);
         const ip_b2: u8 = @truncate((ip >> 8) & 0xFF);
         const ip_b3: u8 = @truncate(ip & 0xFF);
-        
+
         // Calculate prefix from netmask (also in network byte order)
         var prefix: u8 = 0;
         var m = mask;
@@ -231,17 +231,16 @@ pub const TunLinuxDevice = struct {
         }
         // Default to /16 if we got 0 (common VPN subnet)
         if (prefix == 0) prefix = 16;
-        
+
         // Use ip command to configure interface (more reliable than ioctl)
         var cmd_buf: [256]u8 = undefined;
         const cmd = std.fmt.bufPrint(&cmd_buf, "ip addr add {d}.{d}.{d}.{d}/{d} dev {s}", .{
-            ip_b0, ip_b1, ip_b2, ip_b3,
-            prefix,
-            self.getName(),
+            ip_b0,  ip_b1,          ip_b2, ip_b3,
+            prefix, self.getName(),
         }) catch return TunLinuxError.ConfigureFailed;
-        
+
         std.log.info("Running: {s}", .{cmd});
-        
+
         // Run the command
         var child = std.process.Child.init(
             &[_][]const u8{ "sh", "-c", cmd },
@@ -249,110 +248,113 @@ pub const TunLinuxDevice = struct {
         );
         child.stdout_behavior = .Close;
         child.stderr_behavior = .Close;
-        
+
         child.spawn() catch {
             std.log.err("Failed to spawn ip addr command", .{});
             return TunLinuxError.ConfigureFailed;
         };
-        
+
         const result = child.wait() catch {
             std.log.err("Failed to wait for ip addr command", .{});
             return TunLinuxError.ConfigureFailed;
         };
-        
+
         if (result.Exited != 0) {
             std.log.warn("ip addr command returned non-zero: {}", .{result.Exited});
             // Continue anyway - address might already be set
         }
-        
+
         // Set MTU using ip link
         var mtu_cmd_buf: [256]u8 = undefined;
         const mtu_cmd = std.fmt.bufPrint(&mtu_cmd_buf, "ip link set dev {s} mtu {d}", .{
             self.getName(),
             TUN_MTU,
         }) catch return TunLinuxError.ConfigureFailed;
-        
+
         var mtu_child = std.process.Child.init(
             &[_][]const u8{ "sh", "-c", mtu_cmd },
             self.allocator,
         );
         mtu_child.stdout_behavior = .Close;
         mtu_child.stderr_behavior = .Close;
-        
+
         mtu_child.spawn() catch {};
         _ = mtu_child.wait() catch {};
-        
+
         // Bring interface up
         try self.bringInterfaceUp();
-        
+
         self.is_configured = true;
-        
+
         // Log configuration
         std.log.info("TUN device {s} configured: {d}.{d}.{d}.{d}/{d}", .{
             self.getName(),
-            ip_b0, ip_b1, ip_b2, ip_b3,
+            ip_b0,
+            ip_b1,
+            ip_b2,
+            ip_b3,
             prefix,
         });
     }
-    
+
     /// Bring interface up
     fn bringInterfaceUp(self: *TunLinuxDevice) !void {
         const sock_fd = posix.socket(posix.AF.INET, posix.SOCK.DGRAM, 0) catch {
             return TunLinuxError.SocketFailed;
         };
         defer posix.close(sock_fd);
-        
+
         var flags_req = IfreqFlags{
             .ifrn_name = self.device_name,
             .ifru_flags = 0,
             .padding = [_]u8{0} ** 22,
         };
-        
+
         // Get current flags
         if (std.c.ioctl(sock_fd, SIOCGIFFLAGS, @intFromPtr(&flags_req)) < 0) {
             std.log.err("Failed to get interface flags: errno={}", .{std.c._errno().*});
             return TunLinuxError.ConfigureFailed;
         }
-        
+
         // Add UP and RUNNING flags
         flags_req.ifru_flags |= (IFF_UP | IFF_RUNNING);
-        
+
         if (std.c.ioctl(sock_fd, SIOCSIFFLAGS, @intFromPtr(&flags_req)) < 0) {
             std.log.err("Failed to bring interface up: errno={}", .{std.c._errno().*});
             return TunLinuxError.ConfigureFailed;
         }
-        
+
         std.log.debug("Interface {s} is now UP", .{self.getName()});
     }
-    
+
     /// Bring interface down
     fn bringInterfaceDown(self: *TunLinuxDevice) !void {
         const sock_fd = posix.socket(posix.AF.INET, posix.SOCK.DGRAM, 0) catch {
             return TunLinuxError.SocketFailed;
         };
         defer posix.close(sock_fd);
-        
+
         var flags_req = IfreqFlags{
             .ifrn_name = self.device_name,
             .ifru_flags = 0,
             .padding = [_]u8{0} ** 22,
         };
-        
+
         // Get current flags
         if (std.c.ioctl(sock_fd, SIOCGIFFLAGS, @intFromPtr(&flags_req)) < 0) {
             return; // Interface might already be gone
         }
-        
+
         // Remove UP flag
         flags_req.ifru_flags &= ~IFF_UP;
-        
+
         _ = std.c.ioctl(sock_fd, SIOCSIFFLAGS, @intFromPtr(&flags_req));
     }
-    
+
     /// Read a packet from the TUN device
     pub fn read(self: *TunLinuxDevice, buffer: []u8) !?usize {
         const fd = self.fd orelse return TunLinuxError.DeviceNotOpen;
-        
+
         const result = posix.read(fd, buffer);
         if (result) |bytes_read| {
             if (bytes_read > 0) {
@@ -368,21 +370,21 @@ pub const TunLinuxDevice = struct {
             return TunLinuxError.ReadFailed;
         }
     }
-    
+
     /// Write a packet to the TUN device
     pub fn write(self: *TunLinuxDevice, data: []const u8) !usize {
         const fd = self.fd orelse return TunLinuxError.DeviceNotOpen;
-        
+
         const written = posix.write(fd, data) catch {
             return TunLinuxError.WriteFailed;
         };
-        
+
         self.stats.send_bytes += written;
         self.stats.send_packets += 1;
-        
+
         return written;
     }
-    
+
     /// Get statistics
     pub fn getStats(self: *const TunLinuxDevice) TunStats {
         return self.stats;

--- a/src/client/auth_handler.zig
+++ b/src/client/auth_handler.zig
@@ -474,8 +474,7 @@ fn startUdpAcceleration(client: *VpnClient, auth_result: softether_proto.AuthRes
 
     // Use server IP for UDP
     var server_ip_buf: [48]u8 = undefined;
-    const server_ip_str = if (client.server_ip) |addr| formatAddress(addr, &server_ip_buf) else
-        client.config.server_host;
+    const server_ip_str = if (client.server_ip) |addr| formatAddress(addr, &server_ip_buf) else client.config.server_host;
 
     const udp_config = udp_accel_mod.UdpAccelConfig{
         .server_ip = server_ip_str,

--- a/src/core/ip.zig
+++ b/src/core/ip.zig
@@ -22,9 +22,9 @@ pub fn formatAddress(addr: net.Address, buf: []u8) []const u8 {
                 buf,
                 "{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}",
                 .{
-                    bytes[0], bytes[1], bytes[2], bytes[3],
-                    bytes[4], bytes[5], bytes[6], bytes[7],
-                    bytes[8], bytes[9], bytes[10], bytes[11],
+                    bytes[0],  bytes[1],  bytes[2],  bytes[3],
+                    bytes[4],  bytes[5],  bytes[6],  bytes[7],
+                    bytes[8],  bytes[9],  bytes[10], bytes[11],
                     bytes[12], bytes[13], bytes[14], bytes[15],
                 },
             ) catch "";

--- a/src/net/socks.zig
+++ b/src/net/socks.zig
@@ -155,11 +155,14 @@ fn socks5UserPassAuth(tcp: *TcpSocket, username: []const u8, password: []const u
 
     var auth_buf: [513]u8 = undefined;
     var off: usize = 0;
-    auth_buf[off] = 1; off += 1; // version
-    auth_buf[off] = @as(u8, @intCast(username.len)); off += 1;
+    auth_buf[off] = 1;
+    off += 1; // version
+    auth_buf[off] = @as(u8, @intCast(username.len));
+    off += 1;
     for (username, 0..) |b, i| auth_buf[off + i] = b;
     off += username.len;
-    auth_buf[off] = @as(u8, @intCast(password.len)); off += 1;
+    auth_buf[off] = @as(u8, @intCast(password.len));
+    off += 1;
     for (password, 0..) |b, i| auth_buf[off + i] = b;
     off += password.len;
 
@@ -175,31 +178,40 @@ fn socks5Connect(tcp: *TcpSocket, host: []const u8, port: u16) !void {
     var req_buf: [262]u8 = undefined;
     var off: usize = 0;
 
-    req_buf[off] = 5; off += 1; // version
-    req_buf[off] = 1; off += 1; // CONNECT
-    req_buf[off] = 0; off += 1; // reserved
+    req_buf[off] = 5;
+    off += 1; // version
+    req_buf[off] = 1;
+    off += 1; // CONNECT
+    req_buf[off] = 0;
+    off += 1; // reserved
 
     if (net.Address.parseIp4(host, 0)) |addr| {
-        req_buf[off] = @intFromEnum(AddressType.ipv4); off += 1;
+        req_buf[off] = @intFromEnum(AddressType.ipv4);
+        off += 1;
         const ip4_bytes = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
         for (ip4_bytes, 0..) |b, i| req_buf[off + i] = b;
         off += 4;
     } else |_| {
         if (net.Address.parseIp6(host, 0)) |addr| {
-            req_buf[off] = @intFromEnum(AddressType.ipv6); off += 1;
+            req_buf[off] = @intFromEnum(AddressType.ipv6);
+            off += 1;
             for (&addr.in6.sa.addr, 0..) |b, i| req_buf[off + i] = b;
             off += 16;
         } else |_| {
             if (host.len > 255) return SocksError.UnsupportedAddressType;
-            req_buf[off] = @intFromEnum(AddressType.domain); off += 1;
-            req_buf[off] = @as(u8, @intCast(host.len)); off += 1;
+            req_buf[off] = @intFromEnum(AddressType.domain);
+            off += 1;
+            req_buf[off] = @as(u8, @intCast(host.len));
+            off += 1;
             for (host, 0..) |b, i| req_buf[off + i] = b;
             off += host.len;
         }
     }
 
-    req_buf[off] = @as(u8, @intCast(port >> 8)); off += 1;
-    req_buf[off] = @as(u8, @intCast(port & 0xFF)); off += 1;
+    req_buf[off] = @as(u8, @intCast(port >> 8));
+    off += 1;
+    req_buf[off] = @as(u8, @intCast(port & 0xFF));
+    off += 1;
 
     try tcp.writeAll(req_buf[0..off]);
 
@@ -314,18 +326,24 @@ test "SOCKS5 IPv6 address type encoding" {
     var req_buf: [262]u8 = undefined;
     var off: usize = 0;
 
-    req_buf[off] = 5; off += 1;
-    req_buf[off] = 1; off += 1;
-    req_buf[off] = 0; off += 1;
-    req_buf[off] = @intFromEnum(AddressType.ipv6); off += 1;
+    req_buf[off] = 5;
+    off += 1;
+    req_buf[off] = 1;
+    off += 1;
+    req_buf[off] = 0;
+    off += 1;
+    req_buf[off] = @intFromEnum(AddressType.ipv6);
+    off += 1;
 
     const ipv6_bytes = [_]u8{ 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
     for (&ipv6_bytes, 0..) |b, i| req_buf[off + i] = b;
     off += 16;
 
     const port: u16 = 443;
-    req_buf[off] = @as(u8, @intCast(port >> 8)); off += 1;
-    req_buf[off] = @as(u8, @intCast(port & 0xFF)); off += 1;
+    req_buf[off] = @as(u8, @intCast(port >> 8));
+    off += 1;
+    req_buf[off] = @as(u8, @intCast(port & 0xFF));
+    off += 1;
 
     try testing.expectEqual(@as(u8, 5), req_buf[0]);
     try testing.expectEqual(@as(u8, 1), req_buf[1]);

--- a/src/protocol/tunnel.zig
+++ b/src/protocol/tunnel.zig
@@ -628,8 +628,16 @@ test "compressBlock round-trip zlib" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -655,8 +663,16 @@ test "compressBlock empty data round-trip" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -677,8 +693,16 @@ test "compressBlock multiple calls work serial re-use" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -714,8 +738,16 @@ test "batch-level compression wire format" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -726,11 +758,16 @@ test "batch-level compression wire format" {
 
     var raw: [32]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, raw[off..][0..4], 2, .big); off += 4;
-    mem.writeInt(u32, raw[off..][0..4], 4, .big); off += 4;
-    @memcpy(raw[off..][0..4], "test"); off += 4;
-    mem.writeInt(u32, raw[off..][0..4], 3, .big); off += 4;
-    @memcpy(raw[off..][0..3], "xyz"); off += 3;
+    mem.writeInt(u32, raw[off..][0..4], 2, .big);
+    off += 4;
+    mem.writeInt(u32, raw[off..][0..4], 4, .big);
+    off += 4;
+    @memcpy(raw[off..][0..4], "test");
+    off += 4;
+    mem.writeInt(u32, raw[off..][0..4], 3, .big);
+    off += 4;
+    @memcpy(raw[off..][0..3], "xyz");
+    off += 3;
 
     const raw_slice = raw[0..off];
 
@@ -772,8 +809,16 @@ test "compressBlock multiple batches are independent" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -804,8 +849,16 @@ test "decompressBlock rejects garbage" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -815,7 +868,7 @@ test "decompressBlock rejects garbage" {
     defer conn.deinit();
 
     var decompress_buf: [128]u8 = undefined;
-    const garbage = &[_]u8{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    const garbage = &[_]u8{ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
     try std.testing.expectError(error.DecompressionFailed, conn.decompressBlock(garbage, &decompress_buf));
 }
@@ -842,7 +895,11 @@ test "sendBlocks produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -894,7 +951,11 @@ test "sendBlocksZeroCopy produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -946,7 +1007,11 @@ test "sendSinglePacketDirect produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -987,11 +1052,16 @@ test "receiveBlocksBatch parses uncompressed batch from stream" {
     // Build pre-canned stream data: [num_blocks=2][size=4][ABCD][size=3][XYZ]
     var stream_data: [32]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, stream_data[off..][0..4], 2, .big); off += 4;
-    mem.writeInt(u32, stream_data[off..][0..4], 4, .big); off += 4;
-    @memcpy(stream_data[off..][0..4], "ABCD"); off += 4;
-    mem.writeInt(u32, stream_data[off..][0..4], 3, .big); off += 4;
-    @memcpy(stream_data[off..][0..3], "XYZ"); off += 3;
+    mem.writeInt(u32, stream_data[off..][0..4], 2, .big);
+    off += 4;
+    mem.writeInt(u32, stream_data[off..][0..4], 4, .big);
+    off += 4;
+    @memcpy(stream_data[off..][0..4], "ABCD");
+    off += 4;
+    mem.writeInt(u32, stream_data[off..][0..4], 3, .big);
+    off += 4;
+    @memcpy(stream_data[off..][0..3], "XYZ");
+    off += 3;
     const stream = stream_data[0..off];
 
     var read_pos: usize = 0;
@@ -1014,7 +1084,11 @@ test "receiveBlocksBatch parses uncompressed batch from stream" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .compression_initialized = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1035,8 +1109,16 @@ test "receiveBlocksBatch parses compressed blocks" {
     const allocator = std.testing.allocator;
     var conn = TunnelConnection{
         .allocator = allocator,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .context = undefined,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1051,11 +1133,16 @@ test "receiveBlocksBatch parses compressed blocks" {
 
     var wire: [512]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, wire[off..][0..4], 2, .big); off += 4;
-    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c1.len)), .big); off += 4;
-    @memcpy(wire[off..][0..c1.len], c1); off += c1.len;
-    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c2.len)), .big); off += 4;
-    @memcpy(wire[off..][0..c2.len], c2); off += c2.len;
+    mem.writeInt(u32, wire[off..][0..4], 2, .big);
+    off += 4;
+    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c1.len)), .big);
+    off += 4;
+    @memcpy(wire[off..][0..c1.len], c1);
+    off += c1.len;
+    mem.writeInt(u32, wire[off..][0..4], @as(u32, @intCast(c2.len)), .big);
+    off += 4;
+    @memcpy(wire[off..][0..c2.len], c2);
+    off += c2.len;
     const wire_len = off;
 
     var read_pos: usize = 0;
@@ -1078,7 +1165,11 @@ test "receiveBlocksBatch parses compressed blocks" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = true,
         .compression_initialized = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1118,7 +1209,11 @@ test "sendBlocks and receiveBlocksBatch compress round-trip" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = true,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),
@@ -1150,7 +1245,11 @@ test "sendBlocks and receiveBlocksBatch compress round-trip" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = true,
         .compression_initialized = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
@@ -1192,7 +1291,11 @@ test "sendKeepalive produces correct wire format" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -1235,7 +1338,11 @@ test "receiveBlocksBatch detects keepalive" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),
@@ -1277,7 +1384,11 @@ test "receiveBlocksBatch returns WouldBlock on partial data" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),
@@ -1311,7 +1422,11 @@ test "total_send and total_recv counters" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -1322,7 +1437,7 @@ test "total_send and total_recv counters" {
     try std.testing.expectEqual(@as(u64, 0), conn.total_send);
     try std.testing.expectEqual(@as(u64, 0), conn.total_recv);
 
-    const blocks = [_][]const u8{ "ABCD" };
+    const blocks = [_][]const u8{"ABCD"};
     try conn.sendBlocks(&blocks);
     // 4 bytes num_blocks + 4 bytes size + 4 bytes data = 12
     try std.testing.expectEqual(@as(u64, 12), conn.total_send);
@@ -1354,7 +1469,11 @@ test "block format edge cases: zero-length block" {
         .allocator = std.testing.allocator,
         .write_fn = WriteContext.write,
         .context = &wctx,
-        .read_fn = struct { fn f(_: *anyopaque, _: []u8) anyerror!usize { return error.WouldBlock; } }.f,
+        .read_fn = struct {
+            fn f(_: *anyopaque, _: []u8) anyerror!usize {
+                return error.WouldBlock;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = undefined,
         .inflate_stream = undefined,
@@ -1365,7 +1484,7 @@ test "block format edge cases: zero-length block" {
     try std.testing.expectEqual(@as(usize, 0), captured_len);
 
     // Single block with empty data
-    const blocks = [_][]const u8{ "" };
+    const blocks = [_][]const u8{""};
     try conn.sendBlocks(&blocks);
     try std.testing.expectEqual(@as(usize, 4 + 4 + 0), captured_len);
     try std.testing.expectEqual(@as(u32, 1), mem.readInt(u32, captured[0..4], .big));
@@ -1375,10 +1494,12 @@ test "block format edge cases: zero-length block" {
 test "out_data slice length limit in receiveBlocksBatch" {
     var stream_data: [32]u8 = undefined;
     var off: usize = 0;
-    mem.writeInt(u32, stream_data[off..][0..4], 10, .big); off += 4;
+    mem.writeInt(u32, stream_data[off..][0..4], 10, .big);
+    off += 4;
     // Fill rest with plausible-looking block headers
     for (0..10) |_| {
-        mem.writeInt(u32, stream_data[off..][0..4], 4, .big); off += 4;
+        mem.writeInt(u32, stream_data[off..][0..4], 4, .big);
+        off += 4;
     }
     const stream = stream_data[0..off];
 
@@ -1402,7 +1523,11 @@ test "out_data slice length limit in receiveBlocksBatch" {
         .allocator = std.testing.allocator,
         .read_fn = ReadContext.read,
         .context = &rctx,
-        .write_fn = struct { fn f(_: *anyopaque, data: []const u8) anyerror!usize { return data.len; } }.f,
+        .write_fn = struct {
+            fn f(_: *anyopaque, data: []const u8) anyerror!usize {
+                return data.len;
+            }
+        }.f,
         .use_compress = false,
         .deflate_stream = std.mem.zeroes(c.z_stream),
         .inflate_stream = std.mem.zeroes(c.z_stream),


### PR DESCRIPTION
## Description

Apply `zig fmt` formatting to 5 source files that were out of compliance:

- `src/adapter/tun_linux.zig`
- `src/client/auth_handler.zig`
- `src/core/ip.zig`
- `src/net/socks.zig`
- `src/protocol/tunnel.zig`

Also adds `test-logs/` to `.gitignore` to prevent test output artifacts from being tracked.

## Verification

- `zig fmt --check src/` now passes
- Pure formatting + gitignore — no behavioural changes

Closes #75