### PR TITLE
refactor(mayaqua): introduce platform abstraction layer and migrate i…

### DIFF
--- a/docs/CODEBASE_REORGANIZATION.md
+++ b/docs/CODEBASE_REORGANIZATION.md
@@ -1,0 +1,374 @@
+# Codebase Reorganization Proposal
+
+> **Date:** 2026-06-18  
+> **Based on:** SoftEtherVPN C source structure, Ghostty Zig best practices, current codebase analysis  
+> **Target:** Zig 0.15.2 (no 0.16.0 migration)
+
+---
+
+## 1. Current State Analysis
+
+### 1.1 Current Zig Project Layout (`libsoftether/src/`)
+
+```
+src/
+├── adapter/       (11 files, ~3,200 lines) — Platform TUN/TAP + routing
+├── app/           (8 files)               — App lifecycle, signals, daemon
+├── cli/           (5 files, ~2,000 lines) — CLI interface
+├── client/        (10 files, ~5,800 lines) — Client orchestration ← TOO LARGE
+├── core/          (4 files)               — IP utils, types, errors
+├── crypto/        (4 files, ~900 lines)   — SHA-0, hash, AES-CBC
+├── net/           (7 files, ~3,500 lines) — Socket, TLS, HTTP, DNS, UDP
+├── protocol/      (7 files, ~4,800 lines) — SoftEther protocol tunnel/auth/pack
+├── session/       (4 files, ~2,000 lines) — Session state + encryption
+├── tunnel/        (5 files, ~1,500 lines) — ARP, DHCP, data loop
+├── config.zig     (436 lines)             — Config parsing
+├── errors.zig     (60 lines)              — Error types
+├── ffi.zig        (982 lines)             — C ABI exports
+├── lib.zig        (118 lines)             — Module exports
+├── main.zig      (190 lines)              — Entry point
+└── types.zig      (82 lines)              — Type definitions
+```
+
+**Total:** ~67 files, ~28,000-30,000 lines Zig
+
+### 1.2 Problem Files (Need Splitting)
+
+| File | Lines | Problem |
+|------|-------|---------|
+| `client/vpn_client.zig` | 2,787 | Single file does: config, state machine, data loop, diagnostics, reconnect, routing |
+| `protocol/tunnel.zig` | 1,542 | Tunnel framing + compression + keepalive blended together |
+| `protocol/softether_protocol.zig` | 1,548 | 4-step handshake + auth + protocol negotiation in one file |
+| `adapter/utun.zig` | 1,211 | utun device + packet builders + packet queue mixed |
+| `adapter/route.zig` | 994 | IPv4 + IPv6 + heal + sync in one file |
+| `net/tls.zig` | 949 | TLS connect + socket options + config in one file |
+| `session/session.zig` | 1,156 | Session state + key derivation + encryption + queue |
+| `ffi.zig` | 982 | C ABI for everything — no separation |
+
+### 1.3 Reference: SoftEtherVPN C Source Organization
+
+```
+SoftEtherVPN/src/
+├── Mayaqua/        (20 .c files, ~93,000 lines) — PLATFORM ABSTRACTION LAYER
+│   ├── Network.c   (25,448 lines) — Socket I/O, DNS, HTTP, RUDP, TCP/UDP
+│   ├── Microsoft.c (15,763 lines) — Windows OS abstraction
+│   ├── Encrypt.c   (7,360 lines) — All crypto: SHA-0/1, AES, RC4, RSA, DH
+│   ├── Pack.c      (2,573 lines) — Pack/Value serialization
+│   ├── Kernel.c    (2,450 lines) — Threading, timers, process
+│   ├── Memory.c    (5,219 lines) — Custom allocators, buffers
+│   └── TcpIp.c     (4,734 lines) — Protocol header parsing
+│
+├── Cedar/          (61 .c files, ~216,000 lines) — VPN PROTOCOL LAYER
+│   ├── Connection.c  (3,682 lines) — TCP/TLS connection lifecycle
+│   ├── Session.c     (2,500 lines) — Session state machine
+│   ├── Protocol.c    (10,103 lines) — Wire protocol negotiation
+│   ├── Virtual.c     (10,317 lines) — Virtual hub L2 switch
+│   ├── Client.c      (11,172 lines) — Client core
+│   ├── Server.c      (11,127 lines) — Server core
+│   ├── Hub.c         (7,550 lines) — Hub management
+│   ├── Admin.c       (15,113 lines) — RPC admin protocol
+│   ├── Command.c     (23,955 lines) — CLI command handler
+│   ├── Encrypt.c     — Session-layer encryption (RC4)
+│   └── UdpAccel.c    — UDP acceleration
+│
+├── vpnclient/      — Client executable entry point
+├── vpnserver/      — Server executable entry point
+└── vpncmd/         — CLI entry point
+```
+
+**Key architectural insight:** The C code has a strict two-layer separation:
+- **Mayaqua** = OS abstraction + low-level library (no VPN logic)
+- **Cedar** = VPN protocol + business logic (no OS-specific code)
+- **Executables** = thin entry points that link both
+
+### 1.4 Reference: Ghostty Zig Structure (for best practices)
+
+```
+ghostty/src/
+├── main.zig               (dispatcher) — Routes to entrypoint based on build config
+├── Surface.zig            (6,036 lines) — Largest file, but single concern
+├── terminal/              (55+ files)   — Terminal emulation
+│   ├── main.zig                          — Module facade (re-exports)
+│   ├── Terminal.zig / Screen.zig         — Core types
+│   ├── Parser.zig / ansi.zig / csi.zig   — Protocol parsers (separated by concern)
+│   └── kitty/ / tmux/ / osc/ / apc/     — Sub-protocol directories
+├── renderer/              (3 backends)  — Metal, OpenGL, WebGL
+├── apprt/                 (3 runtimes)  — GTK, embedded, browser
+├── os/                    (30+ files)   — Platform-specific, selected via comptime
+├── config/                (20+ files)   — Config parsing split by concern
+├── termio/                (9 files)     — Terminal I/O, exec, threading
+├── cli/                   (25+ files)   — Command implementations, one per command
+└── lib/ / datastruct/ / unicode/ / simd/ — Pure utility libraries
+```
+
+**Key Ghostty patterns to adopt:**
+
+1. **`main.zig` facade in every module** — `pub const Foo = @import("Foo.zig");` — clean API surface
+2. **One concern per file** — max 500-800 lines per file; 6,036 lines is their outlier
+3. **backend/pattern for platform-specific** — separate subdirectory per platform backend
+4. **`build_config.zig`** — central comptime build options, prevents `@import("build_options")` scattering
+5. **Tests co-located** — `test { refAllDecls(@This()); }` in every module facade
+6. **Module naming** — `PascalCase.zig` for types, `snake_case.zig` for utilities, `main.zig` for facades
+
+---
+
+## 2. Proposed Reorganization Map
+
+### 2.1 Mayaqua-equivalent Foundation Layer
+
+Create a Mayaqua equivalent as the bottom layer: pure utilities, no VPN logic.
+
+| Current File(s) | Proposed Module | Splits Into | C Equivalent |
+|-----------------|----------------|-------------|-------------|
+| `net/socket.zig` | `mayaqua/network.zig` | Keep as-is, plus extract | `Network.c` |
+| `net/tls.zig` | `mayaqua/network/` | `socket.zig`, `tls.zig`, `dns.zig` | Part of `Network.c` |
+| `crypto/*` | `mayaqua/encrypt/` | `hash.zig`, `cipher.zig`, `sha0.zig`, `aes.zig` | `Encrypt.c` |
+| `protocol/pack.zig` | `mayaqua/pack.zig` | Keep as-is | `Pack.c` |
+| `core/` | `mayaqua/kernel/` | `ip.zig`, `memory.zig`, `time.zig`, `thread.zig` | `Kernel.c` |
+| `adapter/route.zig` | `mayaqua/tcp_ip.zig` | Route logic + IP utils | `TcpIp.c` |
+| `errors.zig`, `types.zig` | `mayaqua/types.zig` | Merge into one | `MayaquaType.h` |
+| `-` | `mayaqua/secure.zig` | OpenSSL wrapper, certificates | `Secure.c` |
+| `-` | `mayaqua/file.zig` | File I/O, config file parsing | `FileIO.c` |
+
+**Result:** `mayaqua/` module with no VPN logic — pure OS abstraction + crypto + utilities.
+
+### 2.2 Cedar-equivalent VPN Protocol Layer
+
+| Current File(s) | Proposed Module | Splits Into | C Equivalent |
+|-----------------|----------------|-------------|-------------|
+| `client/vpn_client.zig` (2,787) | `cedar/client/` | `connect.zig`, `disconnect.zig`, `data_loop.zig`, `config.zig`, `state.zig`, `diagnostics.zig` | `Client.c` |
+| `client/connection_manager.zig` | `cedar/connection.zig` | Combine with session connection mgmt | `Connection.c` |
+| `session/session.zig` (1,156) | `cedar/session.zig` | Split into `session.zig` + `encrypt.zig` | `Session.c` |
+| `protocol/softether_protocol.zig` (1,548) | `cedar/protocol.zig` | Split into `auth.zig`, `handshake.zig`, `pack.zig` | `Protocol.c` |
+| `protocol/tunnel.zig` (1,542) | `cedar/layer2/` | `tunnel.zig`, `compression.zig`, `keepalive.zig` | Part of `Virtual.c` |
+| `protocol/auth.zig` (718) | `cedar/auth.zig` | Keep (already reasonable) | `Sam.c` |
+| `protocol/watermark.zig` | `cedar/watermark.zig` | Keep | `WaterMark.c` |
+| `net/udp_accel.zig` | `cedar/udp_accel.zig` | Keep + fix to match C cipher | `UdpAccel.c` |
+| `adapter/*` | `cedar/adapter.zig` | Platform adapter interface | Bridge/VLan |
+| `tunnel/arp.zig` | `cedar/arp.zig` | Keep | Part of `Virtual.c` |
+| `tunnel/dhcp.zig` | `cedar/dhcp.zig` | Keep | Part of `Virtual.c` |
+
+**Result:** `cedar/` module with all VPN business logic, no platform-specific code.
+
+### 2.3 Thin Entry Points
+
+| Current File(s) | Proposed | C Equivalent |
+|-----------------|----------|-------------|
+| `main.zig` + `cli/` | `exec/vpnclient/main.zig` | `vpnclient/` |
+| `ffi.zig` | `exec/libsoftether/main.zig` | C library build |
+| `cli/args.zig` → config | `exec/vpnclient/config.zig` | CLI-specific config |
+| `app/` | `exec/vpnclient/app.zig` | App lifecycle |
+
+---
+
+## 3. Detailed File Split Plan
+
+### 3.1 Priority 1: Split `client/vpn_client.zig` (2,787 → ~350 facade)
+
+**Current content breakdown (estimated):**
+
+| Lines | Section | New File |
+|-------|---------|----------|
+| 1-150 | Imports + `ClientConfig` | `cedar/client/config.zig` |
+| 150-210 | Config fields | `cedar/client/config.zig` |
+| 210-260 | `VpnClient` struct decl | `cedar/client/vpn_client.zig` (facade) |
+| 260-400 | Thread lifecycle | `cedar/client/thread.zig` |
+| 400-600 | `connect()` method | `cedar/client/connect.zig` |
+| 600-800 | Auth + session setup | `cedar/client/connect.zig` |
+| 800-900 | `disconnect()` | `cedar/client/disconnect.zig` |
+| 900-1060 | Packet I/O helpers | `cedar/client/io.zig` |
+| 1060-1100 | `sendPacket()`, `receivePacket()` | `cedar/client/io.zig` |
+| 1100-1210 | `processInboundBlock()` | `cedar/client/process.zig` |
+| 1210-1700 | DHCP, ARP, routing | `cedar/client/routing.zig` |
+| 1700-2320 | Data loop (`runDataLoop`) | `cedar/client/data_loop/` |
+| 2320-2370 | Health check (disabled) | `cedar/client/diagnostics.zig` |
+| 2370-2550 | DIAG stats | `cedar/client/diagnostics.zig` |
+| 2550-2710 | `ClientConfigBuilder` | `cedar/client/config.zig` |
+| 2710-2787 | `parseIpv6Address` | `cedar/client/routing.zig` |
+
+### 3.2 Priority 2: Split `protocol/` modules
+
+**`protocol/tunnel.zig` (1,542 → 3 files):**
+
+| Lines | Content | New File |
+|-------|---------|----------|
+| 1-60 | TunnelConnection struct | `cedar/tunnel.zig` |
+| 60-250 | Read/Write state machine | `cedar/tunnel.zig` |
+| 250-430 | `receiveBlocksBatch` | `cedar/tunnel.zig` |
+| 430-470 | `sendBlocksZeroCopy` | `cedar/tunnel.zig` |
+| 470-550 | Compression (zlib) | `cedar/tunnel/compression.zig` |
+| 550-660 | Keepalive send | `cedar/tunnel/keepalive.zig` |
+| 660-end | Tests | Kept at file bottoms |
+
+**`protocol/softether_protocol.zig` (1,548 → 4 files):**
+
+| Lines | Content | New File |
+|-------|---------|----------|
+| 1-450 | Pack building helpers | `cedar/protocol/pack.zig` |
+| 450-600 | Auth structs + builders | `cedar/protocol/auth.zig` |
+| 600-1300 | `performHandshake` (4 auth methods) | `cedar/protocol/handshake.zig` |
+| 1300-end | Server response parsing | `cedar/protocol/response.zig` |
+
+### 3.3 Priority 3: Split `adapter/utun.zig` (1,211 → 2 files)
+
+| Lines | Content | New File |
+|-------|---------|----------|
+| 1-540 | utun device (open/close/read/write) | `adapter/utun.zig` |
+| 540-end | Packet builders (ARP, ND, Router Solicitation) | `adapter/packets.zig` |
+
+### 3.4 Priority 4: Split `session/session.zig` (1,156 → 2 files)
+
+| Lines | Content | New File |
+|-------|---------|----------|
+| 1-360 | Session struct, key derivation | `cedar/session.zig` |
+| 360-660 | Packet queue, encrypt/decrypt | `cedar/session/encrypt.zig` |
+| 660-end | Tests | Kept |
+
+---
+
+## 4. Consolidated Module Map (Final State)
+
+```
+src/
+├── mayaqua/                        # OS abstraction + utilities (NO VPN logic)
+│   ├── main.zig                    # Module facade, re-exports
+│   ├── network.zig                 # Socket I/O (from net/socket.zig)
+│   ├── network/
+│   │   ├── tls.zig                 # TLS wrapper (from net/tls.zig)
+│   │   ├── dns.zig                 # DNS cache (from net/dns_cache.zig)
+│   │   └── http.zig                # HTTP client (from net/http.zig)
+│   ├── encrypt.zig                 # All crypto facade
+│   ├── encrypt/
+│   │   ├── hash.zig                # SHA-0, SHA-1, SHA-256
+│   │   ├── cipher.zig              # AES-CBC, RC4 (for session)
+│   │   └── aes.zig                 # AES-128/256 GCM
+│   ├── pack.zig                    # Pack/Value serialization
+│   ├── kernel.zig                  # Thread, time, memory
+│   ├── kernel/
+│   │   ├── thread.zig              # Thread spawning
+│   │   ├── time.zig                # Timers, tick
+│   │   └── memory.zig              # Allocators, buffers
+│   ├── tcp_ip.zig                  # IP header parsing, route utils
+│   ├── file.zig                    # File I/O, config file
+│   ├── types.zig                   # Shared types (from core/)
+│   └── secure.zig                  # OpenSSL wrapper, certs
+│
+├── cedar/                          # VPN protocol logic (NO platform code)
+│   ├── main.zig                    # Module facade
+│   ├── client.zig                  # Client config facade
+│   ├── client/
+│   │   ├── config.zig              # ClientConfig + builder (~200 lines)
+│   │   ├── connect.zig             # connect(), auth flow (~300 lines)
+│   │   ├── disconnect.zig          # disconnect(), cleanup (~150 lines)
+│   │   ├── thread.zig              # Thread lifecycle (~150 lines)
+│   │   ├── io.zig                  # sendPacket, receivePacket (~200 lines)
+│   │   ├── process.zig             # processInboundBlock (~200 lines)
+│   │   ├── routing.zig             # DHCP+route config (~300 lines)
+│   │   ├── diagnostics.zig         # DIAG, health check (~250 lines)
+│   │   └── data_loop.zig           # runDataLoop (~600 lines)
+│   ├── connection.zig              # TCP connection lifecycle (~500 lines)
+│   ├── connection/
+│   │   ├── manager.zig             # Multi-conn manager (from connection_manager.zig, ~400 lines)
+│   │   └── keepalive.zig           # Keep-alive send/recv (~150 lines)
+│   ├── session.zig                 # Session state, keys (~400 lines)
+│   ├── session/
+│   │   ├── encrypt.zig             # Session encrypt/decrypt queue (~300 lines)
+│   │   └── setup.zig               # Session initialization (~200 lines)
+│   ├── auth.zig                    # Auth protocol (from protocol/auth.zig, ~720 lines)
+│   ├── auth/
+│   │   ├── handler.zig             # Auth handler (from client/auth_handler.zig, ~520 lines)
+│   │   └── password.zig            # SecurePassword, password hash (~150 lines)
+│   ├── protocol.zig                # Wire protocol facade
+│   ├── protocol/
+│   │   ├── handshake.zig           # 4-step handshake (~600 lines)
+│   │   ├── response.zig            # Server response parsing (~400 lines)
+│   │   └── negotiation.zig         # Version negotiation (~200 lines)
+│   ├── tunnel.zig                  # Tunnel connection (~600 lines)
+│   ├── tunnel/
+│   │   ├── compression.zig         # zlib compress/decompress (~150 lines)
+│   │   └── keepalive.zig           # Keepalive messages (~100 lines)
+│   ├── layer2.zig                  # L2 switch facade
+│   ├── layer2/
+│   │   ├── arp.zig                 # ARP handling (from tunnel/arp.zig, ~210 lines)
+│   │   └── dhcp.zig                # DHCP client (from tunnel/dhcp.zig, ~180 lines)
+│   ├── watermark.zig               # Anti-DPI watermark (from protocol/watermark.zig, ~90 lines)
+│   ├── udp_accel.zig               # UDP acceleration (from net/udp_accel.zig, ~650 lines)
+│   └── adapter.zig                 # Platform adapter interface
+│
+├── exec/                           # Entry points (thin)
+│   ├── vpnclient/
+│   │   ├── main.zig                # Entry point (~50 lines)
+│   │   ├── config.zig              # CLI config parsing (~100 lines)
+│   │   └── args.zig                # CLI arguments (from cli/args.zig, ~560 lines)
+│   └── libsoftether/
+│       ├── main.zig                # C library entry point (~50 lines)
+│       └── ffi.zig                 # C ABI exports (from ffi.zig, ~980 lines)
+│
+├── cli/                            # CLI commands (if needed standalone)
+│   ├── display.zig                 # Terminal display helpers (~530 lines)
+│   └── shell.zig                   # Interactive shell (~500 lines)
+│
+└── app/                            # App lifecycle (daemon, signals)
+    ├── daemon.zig                  # Daemon mode
+    └── signals.zig                 # Signal handling
+```
+
+---
+
+## 5. Adoption Strategy
+
+### Phase 1: Structural Only (1-2 days)
+No logic changes — just move files and update imports.
+
+1. Create `mayaqua/` directory structure
+2. Move `crypto/*`, `core/*`, `net/*` into `mayaqua/`
+3. Create `cedar/` directory structure
+4. Split `client/vpn_client.zig` into `cedar/client/` (7 files)
+5. Split `protocol/tunnel.zig` into `cedar/tunnel/` (3 files)
+6. Split `protocol/softether_protocol.zig` into `cedar/protocol/` (3 files)
+7. Update `main.zig` in each module for re-exports
+8. Update `build.zig` to include new paths
+9. Verify build passes
+
+### Phase 2: Rename and Clean (1 day)
+1. Rename structs/functions to match new module names
+2. Clean up dead code identified by RCAs
+3. Add `test { refAllDecls(@This()); }` to each `main.zig`
+4. Add `build_config.zig` for comptime build options
+
+### Phase 3: Fix Known Issues (2-3 days)
+1. Fix AES-256-CBC dead code path
+2. Fix UDP acceleration cipher (RC4/ChaCha20) to match C
+3. Fix password hash (SHA-0 vs SHA-256) if server compatibility needed
+4. Add connection replenishment to multi-conn manager
+
+---
+
+## 6. Targeted File Sizes After Reorganization
+
+| Current File | Lines | After Split | Lines |
+|-------------|-------|-------------|-------|
+| `client/vpn_client.zig` | 2,787 | 9 files @ 150-600 each | ~2,200 total |
+| `protocol/tunnel.zig` | 1,542 | 3 files @ 100-600 each | ~1,200 total |
+| `protocol/softether_protocol.zig` | 1,548 | 3 files @ 200-600 each | ~1,200 total |
+| `adapter/utun.zig` | 1,211 | 2 files @ 500-700 each | ~1,200 total |
+| `adapter/route.zig` | 994 | Keep | 994 (monitor) |
+| `net/tls.zig` | 949 | 2 files | 949 (monitor) |
+| `session/session.zig` | 1,156 | 2 files @ 400-600 each | ~1,000 total |
+| `ffi.zig` | 982 | Keep | 982 (C API is large) |
+
+**Final file count:** ~85 files (up from 67), but largest file < 1,000 lines (except `ffi.zig`).
+
+---
+
+## 7. Key Principles Applied
+
+| Principle | From | How |
+|-----------|------|-----|
+| **Two-layer separation** | SoftEtherVPN C | `mayaqua/` (abstraction) vs `cedar/` (business logic) |
+| **One concern per file** | Zig best practice | No file > 1,000 lines; target < 600 |
+| **`main.zig` facade** | Ghostty | Every module has `main.zig` with `pub const` re-exports |
+| **Tests co-located** | Ghostty, Zig std | `test { refAllDecls(@This()); }` in every `main.zig` |
+| **Comptime build config** | Ghostty `build_config.zig` | Central comptime options, no `@import("build_options")` scattering |
+| **Platform backends** | Ghostty `apprt/`, `renderer/` | Separate subdirectory per platform for complex adapters |
+| **Thin entry points** | C `vpnclient/`, `vpnserver/`, `vpncmd/` | `exec/vpnclient/main.zig` is ~50 lines |

--- a/docs/rca/AES256_CBC_SESSION_ENCRYPTION.md
+++ b/docs/rca/AES256_CBC_SESSION_ENCRYPTION.md
@@ -1,0 +1,325 @@
+# RCA-01: AES-256-CBC Session Encryption
+
+> **Date:** 2026-06-18  
+> **Status:** Final  
+> **Supersedes:** N/A  
+> **Covered in SCOPE.md:** RCA-01 (HIGH)
+
+---
+
+## Executive Summary
+
+The AES-256-CBC session encryption layer — designed to provide per-packet encryption on top of TLS — is **completely dead code**. The `encrypt()` / `decrypt()` methods are never called from the actual data path. Tunnel data flows as raw Ethernet frames over TLS without any application-layer encryption. Additionally, even if the encryption were wired up, two independent bugs would cause either immediate data corruption (key derivation uses SHA-256 instead of SHA-0, producing wrong AES keys) or silent data loss (the encrypted output is freed without being transmitted).
+
+The net effect is that the tunnel relies solely on TLS for confidentiality — despite `use_encrypt=true` being set and "Session established with AES-256-CBC encryption" being logged.
+
+---
+
+## Architecture Context
+
+```
+┌───────────────────┐
+│  TLS 1.3 Tunnel   │  ← provides transport security (AES-128/256-GCM)
+│  (SSL_read/write) │
+└────────┬──────────┘
+         │
+┌────────▼──────────┐
+│ Application Layer │  ← was supposed to add AES-256-CBC per-packet encryption
+│ SoftEther blocks  │    on TOP of TLS (defense-in-depth)
+└────────┬──────────┘
+         │
+┌────────▼──────────┐
+│ TUN Adapter       │  ← raw IP packets
+└───────────────────┘
+```
+
+The SoftEther protocol specification calls for **double encryption**: TLS protects the transport, and AES-256-CBC protects each individual tunnel block. This follows the original C implementation at `SoftEtherVPN/src/Cedar/Encrypt.c`. The Zig implementation has the structure but the encryption calls were never wired into the data loop.
+
+---
+
+## Root Cause
+
+### Bug #1: Dead code — encrypt/decrypt never called from data path
+
+**Files:** `src/client/vpn_client.zig`, `src/session/wrapper.zig`  
+**Call chain that should exist** (but doesn't):
+
+```
+Data loop (read from TLS)
+  → receiveBlocksBatch
+  → processInboundBlock
+  → SessionWrapper.decrypt()  ← NOT CALLED
+  → TUN write
+
+Data loop (read from TUN)
+  → wrapIpInEthernet
+  → SessionWrapper.encrypt()  ← NOT CALLED
+  → sendBlocksZeroCopy
+  → TLS write
+```
+
+The actual call chain:
+
+```
+Data loop (read from TLS)
+  → receiveBlocksBatch          ← reads raw, encrypted blocks
+  → processInboundBlock         ← processes AS-IS, no decryption
+  → TUN write                   ← writes raw encrypted data to TUN!
+
+Data loop (read from TUN)
+  → wrapIpInEthernet
+  → sendBlocksZeroCopy          ← sends raw, unencrypted blocks
+  → TLS write
+```
+
+**Grep proof:**
+
+```
+$ grep -rn "client.sendPacket\|self\.sendPacket\|client\.receivePacket\|self\.receivePacket\|\.encrypt(" src/client/ | grep -v test
+→ No results found
+```
+
+The `VpnClient` struct has `sendPacket()` and `receivePacket()` methods, but they are **defined, never called** — no caller exists anywhere in the codebase.
+
+### Bug #2: Encrypted output freed without transmission
+
+**File:** `src/client/vpn_client.zig` — hypothetical `sendPacket()`  
+**Lines:** 1072-1075
+
+Even if `sendPacket()` were called, it contains a critical bug:
+
+```zig
+if (self.config.use_encrypt) {
+    const encrypted = sess.encrypt(self.allocator, data) catch |err| {
+        std.log.err("Failed to encrypt packet: {}", .{err});
+        return;
+    };
+    defer self.allocator.free(encrypted);
+    // ← encrypted is freed here but NEVER TRANSMITTED
+    // ← the original `data` is also never transmitted
+}
+// ← nothing is ever written to any output
+```
+
+The encrypted result is stored in a local variable, `defer`-freed at function exit, and **never passed to any send function**. The function returns without transmitting anything in either branch.
+
+### Bug #3: Wrong key derivation algorithm
+
+**File:** `src/session/session.zig` — `SessionKeys.deriveFromAuth()`  
+**Lines:** 316-347
+
+The original SoftEther protocol specifies **SHA-0** for session key derivation:
+
+```
+send_key = SHA-0(session_key || server_challenge || 0x01)
+recv_key = SHA-0(session_key || server_challenge || 0x02)
+```
+
+The Zig implementation uses **SHA-256**:
+
+```
+send_key = SHA-256(session_key || server_challenge || 0x01)  ← WRONG
+recv_key = SHA-256(session_key || server_challenge || 0x02)  ← WRONG
+```
+
+Even if encryption were wired up, the derived AES keys would NOT match what the server computes, causing immediate decryption failure and connection drop.
+
+### Bug #4: Orphaned session queue path
+
+**File:** `src/session/session.zig` — `getNextSendPacket()`, `receivePacket()`  
+**Lines:** ~400-500
+
+The `Session` struct has a complete internal queue-based encryption path:
+- `getNextSendPacket()` → dequeues a raw block, encrypts it, returns encrypted block
+- `receivePacket()` → takes encrypted block, decrypts it, enqueues raw data
+
+These functions are never called from ANYWHERE in the codebase (confirmed by grep). The entire session queue mechanism is orphaned dead code that exists only to pass unit tests.
+
+### Bug #5: `use_encrypt=true` has no effect
+
+**File:** `src/client/vpn_client.zig` — `connect()`  
+**Lines:** ~880-890
+
+```zig
+if (!self.config.use_encrypt) {
+    std.log.warn("Encryption disabled — tunnel data will NOT be encrypted at application layer", .{});
+}
+```
+
+This warning is logged and `use_encrypt` is set to `true`. But since nothing in the data path checks `use_encrypt`, the flag is cosmetic. The log message "Session established with AES-256-CBC encryption" is misleading.
+
+---
+
+## Detection
+
+This RCA was discovered during a systematic code review of encryption code paths, triggered by:
+
+1. **Grep for `encrypt` callers** — found zero callers of `SessionWrapper.encrypt()` in the actual data path
+2. **Tracing `sendPacket`** — found it's never called; grep for `sendPacket` across entire `src/` returned only the definition
+3. **Code review of `sendPacket()`** — noticed the encrypted result is freed without being transmitted
+4. **Reviewing `session.zig` key derivation** — discovered SHA-256 used instead of SHA-0 (protocol specification)
+
+---
+
+## Impact Assessment
+
+| Impact | Severity | Description |
+|--------|----------|-------------|
+| Confidentiality | **NONE** | TLS 1.3 provides AES-128/256-GCM encryption. The application-layer AES-CBC was additive defense-in-depth. Without it, the tunnel is still secure against passive interception. |
+| Server compatibility | **MINIMAL** | The SoftEther server's `use_encrypt` flag controls whether the server applies AES-CBC to tunnel blocks. If the server sends encrypted blocks (because it set `use_encrypt=true`), our client would receive raw ciphertext as "Ethernet frames" and write garbage to TUN. This would break all connectivity immediately on connection. Since no such breakage is reported, the server likely does NOT encrypt either (or uses a different negotiation path). |
+| Code correctness | **CRITICAL** | The dead code represents 1156 lines of untested, unexercised session logic. If someone later tries to wire it up, they'll hit: (a) the `sendPacket()` free-before-transmit bug, (b) the SHA-256 vs SHA-0 mismatch, and (c) potential API incompatibilities between the two `Aes256Cbc` implementations. |
+
+---
+
+## Fix Required
+
+The subsystem needs one of two approaches:
+
+**Option A: Remove dead code** (recommended if no plan to wire up encryption)
+
+```
+- Remove SessionWrapper.encrypt() and decrypt()
+- Remove VpnClient.sendPacket() and receivePacket()
+- Remove Session.getNextSendPacket() and receivePacket()
+- Remove the session.cipher internal queue logic
+- Keep SessionKeys.deriveFromAuth() for the UDP acceleration path (if used)
+- Change the "AES-256-CBC" log message to reflect actual encryption status
+```
+
+**Option B: Wire up encryption correctly** (recommended for protocol compliance)
+
+```
+- Fix VpnClient.sendPacket() to actually transmit the encrypted data
+- Fix key derivation to use SHA-0 (or SHA-1 for modern compatibility)
+- Insert encrypt/decrypt calls in the data path:
+  receiveBlocksBatch → decrypt → processInboundBlock
+  wrapIpInEthernet → encrypt → sendBlocksZeroCopy
+- Add unit tests with known test vectors from the C implementation
+- Verify against an actual server with use_encrypt=true
+```
+
+---
+
+## Key Discovery
+
+The investigation uncovered a deeper finding: **the `wrapper.zig` encrypt/decrypt functions are a SECOND, incompatible AES-256-CBC implementation**. There are now TWO separate `Aes256Cbc` structs in the codebase:
+
+| File | API | Used by | Status |
+|------|-----|---------|--------|
+| `session/session.zig:50-152` | `encrypt(alloc, []u8) → []u8` (allocating, PKCS7 padding) | Session wrapper → dead code | Orphaned |
+| `crypto/cipher.zig:107-168` | `encrypt(data: []u8) → void` (in-place, block-aligned) | UDP acceleration (`udp_accel.zig`) | ACTIVE |
+
+Both are correct implementations sharing the same core AES engine (`std.crypto.core.aes.Aes256`). The API difference exists because they serve different use cases (allocating vs in-place). However, having two implementations with different APIs creates maintenance risk — changes to one won't be reflected in the other.
+
+---
+
+## Lesson Learned
+
+### 1. Dead code must be tagged or removed
+Any function defined but never called in the data path will inevitably drift out of sync with the actual protocol. If kept for future use, it must have:
+- Explicit dead-code annotations in the file header
+- Tests that validate against the live protocol (not just unit tests)
+- A tracking issue linking to the feature that will call it
+
+### 2. Log messages must reflect actual behavior
+"Session established with AES-256-CBC encryption" implies a security property that does not exist. Log messages that describe security states must be verified against the actual code path, not just configuration flags.
+
+### 3. Encryption code must be tested against known vectors
+Key derivation, encryption, and decryption must have test vectors from the reference implementation (C source). A SHA-0 vs SHA-256 mismatch would be caught immediately by a test vector comparison.
+
+---
+
+## Prevention Checklist
+
+- [ ] Every non-trivial function has at least one caller in the live code path
+- [ ] Dead code is annotated with `// UNUSED` or removed
+- [ ] Security-sensitive log messages are verified against the actual code path, not config flags
+- [ ] Key derivation has test vectors from the reference implementation
+- [ ] All encryption/decryption paths are exercised in integration tests
+- [ ] Two implementations of the same algorithm share a test harness that runs both against known vectors
+
+---
+
+---
+
+## Cross-Validation Against C Source
+
+After writing this RCA, the Zig implementation was validated against the reference C source at `SoftEtherVPN/src/`. The following corrections and clarifications apply:
+
+### Finding #1: C source uses RC4, not AES-256-CBC, for per-packet encryption
+
+**Claim in RCA:** The C source applies AES-256-CBC per-packet encryption on top of TLS.
+
+**Actual C behavior:** The C source has two **mutually exclusive** encryption modes:
+
+```c
+// Protocol.c:4188-4195
+if (s->UseEncrypt && s->UseFastRC4 == false)
+    s->UseSSLDataEncryption = true;   // Mode 1: TLS encryption via SSL socket
+else
+    s->UseSSLDataEncryption = false;  // Mode 2: RC4 per-packet or no encryption
+```
+
+**Mode 1 (TLS):** `UseSSLDataEncryption=true` → `Recv()`/`Send()` call `SSL_read()`/`SSL_write()` through OpenSSL. No application-layer encryption on top.
+
+**Mode 2 (Fast RC4):** When `UseFastRC4=true`, TLS is NOT used for data. Instead, the raw TCP socket is used and per-packet RC4 encryption is applied in `WriteSendFifo`/`WriteRecvFifo` (`Connection.c:644-676`):
+
+```c
+void WriteSendFifo(SESSION *s, TCPSOCK *ts, void *data, UINT size)
+{
+    if (s->UseFastRC4) { Encrypt(ts->SendKey, data, data, size); }  // RC4
+    WriteFifo(ts->SendFifo, data, size);
+}
+```
+
+The `Encrypt()` function is an RC4 wrapper (`Encrypt.c:5316-5319`), using `NewCrypt()` which calls `RC4_set_key()` (`Encrypt.c:5290-5299`). RC4 keys are 128-bit random values from `Rand()` (`Protocol.c:8480-8490`).
+
+**AES-256-CBC** exists in the C codebase but is used ONLY in the IPsec IKE code (`IPsec_IkePacket.c:2869`), NOT in the VPN session data path.
+
+### Finding #2: SHA-0 is used for password hashing, not for key derivation
+
+**Claim in RCA:** Key derivation uses SHA-0 (not SHA-256).
+
+**Actual C behavior:** SHA-0 is used in `SecurePassword()` (`Sam.c:108-123`):
+```c
+void SecurePassword(void *secure_password, void *password, void *random)
+{
+    Hash(secure_password, b->Buf, b->Size, true);  // sha=true → SHA-0
+}
+```
+
+Where `Hash(..., true)` calls `Internal_SHA0()` (`Encrypt.c:5232`). The SHA-0 implementation is confirmed by the missing rotation in the message schedule:
+```c
+W[t] = (1,W[t-3] ^ W[t-8] ^ W[t-14] ^ W[t-16]);  // SHA-0: NO rotation
+// SHA-1 would be: W[t] = rol(1,W[t-3] ^ W[t-8] ^ W[t-14] ^ W[t-16]);
+```
+
+The Zig implementation uses SHA-256 for password hashing, which is a protocol deviation but actually SECURITY-IMPROVING (SHA-0 is cryptographically broken).
+
+### Finding #3: The mutual exclusivity of TLS vs application encryption
+
+The Zig codebase has TLS encryption (SSL_read/SSL_write in the data path) AND unused AES-256-CBC functions. The C source shows these are meant to be alternatives, not layers. The Zig implementation chose TLS-only (Mode 1) which is the modern, secure default.
+
+### Implications for RCA Findings
+
+| RCA Finding | C Source Confirmation | Impact |
+|-------------|----------------------|--------|
+| Dead AES-256-CBC code | ✅ C also has dead AES-CBC (only in IPsec code) | No change — both codebases have unused AES-CBC |
+| Key derivation uses SHA-256 vs SHA-0 | ⚠️ C uses SHA-0, Zig uses SHA-256 | Zig is actually MORE secure (SHA-0 broken) but INCOMPATIBLE with standard SoftEther servers expecting SHA-0 hashing |
+| Modes are mutually exclusive | ✅ TLS and per-packet encryption are never both active | The Zig `use_encrypt=true` + TLS is correct behavior per C spec |
+| Two AES-256-CBC implementations | Not applicable to C | Both Zig implementations share same core AES engine |
+
+---
+
+## References
+
+- `src/session/wrapper.zig` — Dead encrypt/decrypt (full file, 150 lines)
+- `src/session/session.zig` — Session key derivation (lines 316-347), two Aes256Cbc implementations (lines 50-152)
+- `src/client/vpn_client.zig` — `sendPacket()`/`receivePacket()` (lines ~1060-1100, never called)
+- `src/crypto/cipher.zig` — Second Aes256Cbc implementation (lines 107-168), used by UDP acceleration
+- `src/protocol/auth.zig` — Auth exchange (session key passing)
+- `SoftEtherVPN/src/Cedar/Encrypt.c` — Reference C RC4 encryption + SHA-0 implementation
+- `SoftEtherVPN/src/Cedar/Connection.c — WriteSendFifo/WriteRecvFifo (lines 644-676)
+- `SoftEtherVPN/src/Cedar/Protocol.c` — Encryption mode selection (lines 4188-4195)
+- `SoftEtherVPN/src/Cedar/Ipsec_IkePacket.c` — Only caller of AES-256-CBC in C (lines 2869, 2906)
+- SCOPE.md RCA-01

--- a/docs/rca/MULTI_TCP_CONNECTION_MANAGER.md
+++ b/docs/rca/MULTI_TCP_CONNECTION_MANAGER.md
@@ -1,0 +1,280 @@
+# RCA-02: Multi-TCP Connection Manager
+
+> **Date:** 2026-06-18  
+> **Status:** Final  
+> **Supersedes:** N/A  
+> **Covered in SCOPE.md:** RCA-02 (HIGH)
+
+---
+
+## Executive Summary
+
+The Multi-TCP Connection Manager provides parallel TCP connections between client and server for increased throughput. It has 10 confirmed historical bugs, ranging from throughput collapse (S2C deadlock) to total connectivity loss (DHCP direction deadlock). The design also has a fundamental gap: **connections that die are removed but never replaced**, causing permanent throughput degradation. Despite this, the single-connection path (which is the default and the only tested configuration in recent sessions) works correctly.
+
+---
+
+## Architecture Context
+
+```
+┌────────────────────────────┐
+│     ConnectionManager       │
+│  max_connections = 1..32   │
+│  half_connection = bool    │
+├────────────────────────────┤
+│  ┌─ ManagedConnection[0] ──┐│
+│  │ direction: bidirectional││  ← Primary (established first)
+│  │ pending_bytes: 12345    ││
+│  │ established: true       ││
+│  └─────────────────────────┘│
+│  ┌─ ManagedConnection[1] ──┐│
+│  │ direction: C2S          ││  ← Upload-only (half-conn mode)
+│  │ pending_bytes: 6789     ││
+│  │ established: true       ││
+│  └─────────────────────────┘│
+│  ┌─ ManagedConnection[2] ──┐│
+│  │ direction: S2C          ││  ← Download-only (half-conn mode)
+│  │ pending_bytes: 0        ││
+│  │ established: true       ││
+│  └─────────────────────────┘│
+└────────────────────────────┘
+     │
+     ▼
+┌────────────────────────────┐
+│   SendTunnelHelper.get()    │
+│   selectSendConnection()    │  ← least-loaded by pending_bytes
+│   → returns best connection │
+└────────────────────────────┘
+     │
+     ▼
+┌────────────────────────────┐
+│   poll() fd set built by    │
+│   buildPollFds()            │  ← all recv-capable connections
+│   forEachReadable()         │  ← iterates ready connections
+└────────────────────────────┘
+```
+
+---
+
+## Root Causes
+
+### Bug #1: Half-Connection S2C Deadlock (skip_poll + kernelRecvQueue)
+
+**File:** `src/client/connection_manager.zig:262-274`  
+**Severity:** Critical (total throughput collapse)
+
+In half-connection mode, the primary connection is `C2S` (upload-only, `canRecv=false`). The `forEachReadable()` iterator initially only checked `poll_fds[].revents & POLLIN` for readability. When the `skip_poll` optimization was active (poll was skipped because SSL had pending data), the fd's `revents` stayed at 0 (not refreshed), and `hasPending()` returned false because OpenSSL's internal buffer was empty. But `kernelRecvQueue() > 0` — data was in the kernel recv buffer, waiting to be read by SSL_read.
+
+The S2C download-only connection never had this check, causing a deadlock where unread data sat in the kernel buffer forever. The connection was established but never drained.
+
+**Fix:** Added `conn.tls_socket.kernelRecvQueue() > 0` to the readability test.
+
+---
+
+### Bug #2: DHCP Direction Deadlock
+
+**File:** `src/client/connection_manager.zig:297-315`  
+**Severity:** Critical (no connectivity)
+
+In half-connection mode, the primary connection is `client_to_server` (upload-only). DHCP responses from the server need to be RECEIVED, but the primary can't receive. Additional S2C (download-only) connections haven't been established yet during the DHCP phase (they're created after the session is active).
+
+The client never receives DHCP OFFER/ACK → no IP address → no connectivity.
+
+**Fix:** `enableDhcpBidirectional()` temporarily overrides the primary's direction to `bidirectional` during DHCP. `restoreDhcpDirections()` restores it after DHCP completes.
+
+**Residual risk:** If DHCP doesn't complete within the grace period and the override is reverted by a timer, the client loses receive capability while still waiting for DHCP responses — a permanent deadlock.
+
+---
+
+### Bug #3: Inbound Drain Premature Stop (macOS 10ms)
+
+**File:** `src/client/vpn_client.zig:1904-1909`  
+**Severity:** High (throughput collapse)
+
+The drain loop's exit condition was:
+```zig
+if (!conn.tls_socket.hasPending()) break;
+```
+
+This only checked OpenSSL's internal buffer (already-decrypted data). If data had arrived in the kernel recv buffer but hadn't been decrypted yet, `hasPending()` returned false and the drain exited. The loop went back to `poll()`, which on macOS can sleep 10ms even with `poll(timeout=0)`. During that 10ms, the server's send window closed → throughput collapse.
+
+**Fix:** Added kernel check:
+```zig
+if (!conn.tls_socket.hasPending() and conn.tls_socket.kernelRecvQueue() == 0) break;
+```
+
+---
+
+### Bug #4: Outbound Starvation During Download (skip_poll)
+
+**File:** `src/client/vpn_client.zig:2054-2061`  
+**Severity:** High (DL ACK starvation → throughput drop)
+
+When `skip_poll = true` (OpenSSL has pending decrypted data), the poll didn't run, so `tun_readable` was always false (poll revents are stale). The outbound section guarded on `tun_readable`, which meant no outbound processing during heavy download → DL ACKs never sent → server's congestion window collapsed.
+
+**Fix:** Changed the guard to `if (is_configured and (tun_readable or skip_poll))`.
+
+---
+
+### Bug #5: Non-Primary Connection Death Degrades Throughput
+
+**File:** `src/client/connection_manager.zig:330-343`  
+**Severity:** Medium (gradual throughput loss)
+
+When a secondary connection dies, `cleanupDead()` removes it silently. The session continues on remaining connections, but aggregate throughput is permanently reduced. `needsMoreConnections()` returns true after a death, but **nothing in the data loop actually establishes new connections**. The session never recovers its original capacity.
+
+**Design limitation:** Connection replenishment is not implemented. A long-running session with intermittent connection failures will degrade to single-connection throughput.
+
+---
+
+### Bug #6: `last_iter_had_work` Sticky-True (iOS CPU Limit)
+
+**File:** `src/client/vpn_client.zig:1804-1815`  
+**Severity:** High (process killed on iOS)
+
+The `last_iter_had_work` flag was set true but never cleared on idle iterations. This forced `poll(timeout=0)` on every iteration, causing a 50k iters/sec busy-spin. iOS's CPU-wakeup-limit killed the process after 45001 wakes in 18 seconds.
+
+**Fix:** Clear `last_iter_had_work = false` at the top of each iteration; OR-set it true only when real work is observed.
+
+---
+
+### Bug #7: Sendq Throttle Using MAX Instead of AVERAGE
+
+**File:** `src/client/vpn_client.zig:2070-2086`  
+**Severity:** Medium (unfair throttling in multi-conn)
+
+The send queue throttle used `MAX` of kernelSendQueue across all connections. One connection with a full buffer (e.g., slow path) would throttle ALL connections to minimum batch size, including the fast ones.
+
+**Fix:** Changed to `AVERAGE` sendq across established connections for multi-conn mode. Only the aggregate queue depth matters — a single slow connection doesn't penalize the others.
+
+---
+
+### Bug #8: Connection Replenishment Gap
+
+**File:** `src/client/session_setup.zig`, `src/client/connection_manager.zig`  
+**Severity:** Medium (permanent throughput degradation)
+
+`establishAdditionalConnections()` runs once during initial setup. After connections die (detected by `cleanupDead()`), `needsMoreConnections()` returns true, but no code path ever calls the establishment function again. The session permanently loses capacity until the next full reconnect.
+
+---
+
+### Bug #9: TUN Write Backpressure Not Applied in ProcessInboundBlock
+
+**File:** `src/client/vpn_client.zig:1135`  
+**Severity:** Medium (packet drops during TUN backpressure)
+
+`dev.write()` can return `EAGAIN` when the TUN kernel buffer is full (application not reading). The error is caught and `tun_write_blocked = true` is set, but the drain loop's check for this flag may exit the multi-conn drain as well. The write itself already lost the packet.
+
+---
+
+## Detection
+
+Multi-connection issues manifest as:
+- **Throughput drop over time** as connections die without replacement
+- **Upload works but download doesn't** in half-connection mode (S2C direction issues)
+- **DHCP never completes** in half-connection mode
+- **DL collapses during UL** (single-TCP head-of-line blocking — inherent to single connection, mitigated by multi-conn but not eliminated)
+
+DIAG metrics for diagnosis:
+```
+Compare multi-conn vs single-conn throughput stability
+Look for established=false in connection log
+Monitor sendq AVG vs MAX divergence
+Check for "Connection lost (multi-conn)" warnings
+```
+
+---
+
+## Lessons Learned
+
+### 1. Direction-aware I/O requires careful lifecycle management
+Half-connection directions create deadlock windows (DHCP phase, poll skip). Any code that temporarily modifies directions must have restoration guarantees, even in error paths.
+
+### 2. Connection replenishment must be part of the data loop
+If the data loop can lose connections, it must also be able to create new ones. A `needsMoreConnections()` check without a corresponding establishment path is a bug waiting to happen.
+
+### 3. Least-loaded scheduling needs proper decay tuning
+The `pending_bytes` decay rate (10,000 bytes/iteration) was chosen empirically. If the decay rate doesn't match the actual drain rate, the scheduler becomes either round-robin (too fast) or static (too slow).
+
+---
+
+## Prevention Checklist
+
+- [ ] Direction overrides have guaranteed restoration (even on error paths)
+- [ ] Connection death triggers either replacement or explicit degradation notification
+- [ ] The `last_iter_had_work` flag is cleared at the top of each iteration
+- [ ] Multi-conn throttle uses AVERAGE sendq, not MAX
+- [ ] Readability checks include both `hasPending()` and `kernelRecvQueue() > 0`
+- [ ] Outbound guard checks both `tun_readable` and `skip_poll`
+- [ ] `needsMoreConnections()` either triggers connection establishment or is removed
+- [ ] Send queue decay rate is verified against actual throughput measurements
+
+---
+
+## References
+
+- `src/client/connection_manager.zig` — Full file (387 lines)
+- `src/client/connection.zig` — Individual connection state (661 lines)
+- `src/client/session_setup.zig` — Additional connection establishment (52-127)
+- `src/tunnel/data_loop.zig` — Data loop state (422 lines)
+- `src/client/vpn_client.zig` — Multi-conn data path integration (scattered)
+- `src/protocol/softether_protocol.zig` — Auth negotiation for max_connection/half_connection
+- `SoftEtherVPN/src/Cedar/Session.c` — C reference: `ClientAdditionalConnectChance()` (lines 950-1007)
+- `SoftEtherVPN/src/Cedar/Connection.c` — C reference: `LateCount`-based send selection (lines 1101-1147)
+- SCOPE.md RCA-02
+
+---
+
+## Cross-Validation Against C Source
+
+After writing this RCA, the Zig implementation was validated against the reference C source at `SoftEtherVPN/src/Cedar/`. Two significant discrepancies were found:
+
+### Discrepancy #1: Connection Replenishment
+
+**RCA Claim:** "Connections that die are removed but never replaced."
+
+**Actual C behavior:** `Session.c:950-1007` `ClientAdditionalConnectChance()` actively monitors `CurrentNumConnection < MaxConnection` and spawns new connection threads when needed:
+
+```c
+void ClientAdditionalConnectChance(SESSION *s)
+{
+    if (s->CurrentNumConnection >= s->MaxConnection) return;
+    if (s->ClientAdditionalConnectionCheckNextTick == 0 || s->ClientAdditionalConnectionCheckNextTick <= s->H->Tick)
+    {
+        s->ClientAdditionalConnectionCheckNextTick = s->H->Tick + (UINT)GenRandInterval(500, 1500);
+        ClientAddAdditionalConnection(s);
+    }
+}
+```
+
+`ClientAddAdditionalConnection()` creates a new TCP/TLS connection, authenticates it with the session ticket/key, and adds it to the connection pool. The Zig implementation lacks this replenishment entirely.
+
+### Discrepancy #2: Load Balancing Metric
+
+**RCA Claim:** Selection is "least-loaded based on `pending_bytes`" with a decay function.
+
+**Actual C behavior:** The C source uses `LateCount` (a packet-delay counter) as the selection metric for TCP connections, and `LastRecvTime` for R-UDP connections:
+
+```c
+// Connection.c:1101-1147
+if (ts->UdpAccel == NULL)  // TCP connection
+{
+    result = ts->LateCount;  // ← KEY: delay count, NOT pending_bytes
+}
+else  // R-UDP connection
+{
+    result = (UINT)(s->Now - ts->UdpAccel->LastRecvTime);  // recency-based
+}
+```
+
+`LateCount` is incremented whenever a `Send` call returns `SOCK_LATER` (write would block), and decayed over time. This directly measures **connection congestion** — a connection whose send buffer is full accumulates `LateCount` and gets skipped. The `pending_bytes` mechanism in Zig approximates this but uses a different decay model (10,000 bytes/iteration uniform decay vs the C's event-driven `LateCount`).
+
+### Implications for Zig Implementation
+
+| Aspect | Zig | C Reference | Action Needed |
+|--------|-----|-------------|---------------|
+| Connection replenishment | ❌ None | ✅ `ClientAdditionalConnectChance()` | Add replenishment monitor to data loop |
+| Load balancing metric | `pending_bytes` decay | `LateCount` (send delay counter) | Consider switching to event-driven congestion signal |
+| Non-primary death handling | Silent removal | Silent removal (same) | ✅ No change needed |
+| In-order delivery | No inter-connection ordering | No inter-connection ordering (same) | ✅ Correct |
+
+

--- a/docs/rca/PERFORMANCE_REGRESSION.md
+++ b/docs/rca/PERFORMANCE_REGRESSION.md
@@ -471,3 +471,24 @@ Before merging any change to the data loop, verify:
 | receiveBlocksBatch | `src/protocol/tunnel.zig` | 260-420 |
 | sendBlocksZeroCopy | `src/protocol/tunnel.zig` | 428-464 |
 | DIAG logging | `src/client/vpn_client.zig` | 2370-2420 |
+
+---
+
+## Appendix C: Cross-Validation Methodology
+
+Every RCA in this directory should be cross-validated against the reference C implementation at `../../SoftEtherVPN/src/` before finalization. The C source is the protocol specification. Deviations identified during cross-validation for the initial RCAs:
+
+| RCA | Discrepancies Found | Corrective Action |
+|-----|--------------------|--------------------|
+| AES-256-CBC | C uses RC4 not AES-CBC; modes are mutually exclusive (TLS xor RC4) | Added cross-validation section |
+| Multi-TCP | C has connection replenishment (`ClientAdditionalConnectChance`), uses `LateCount` not `pending_bytes` | Added cross-validation section |
+| UDP Accel | C uses RC4/ChaCha20 (not AES-CBC), has retransmission/RTT backoff, NAT-T re-probing | Added cross-validation section |
+
+### Cross-validation checklist for future RCAs:
+
+- [ ] Compare encryption algorithms (Zig vs C — should match)
+- [ ] Compare state machine transitions (session setup, auth, data flow)
+- [ ] Compare key sizes and derivation methods
+- [ ] Compare error handling (timeout, WouldBlock, disconnect)
+- [ ] Compare version negotiation fields and defaults
+- [ ] Compare configuration defaults (reconnect, encryption, compression)

--- a/docs/rca/UDP_ACCELERATION_RUDP.md
+++ b/docs/rca/UDP_ACCELERATION_RUDP.md
@@ -1,0 +1,362 @@
+# RCA-03: UDP Acceleration (RUDP)
+
+> **Date:** 2026-06-18  
+> **Status:** Final  
+> **Supersedes:** N/A  
+> **Covered in SCOPE.md:** RCA-03 (HIGH)
+
+---
+
+## Executive Summary
+
+The UDP Acceleration (RUDP) subsystem provides an alternative data path over UDP for reduced latency and improved throughput. The implementation has 10 identified gaps, including a critical sequencing bug where the high-level `performHandshake()` convenience function passes `null` for the bulk key exchange, making the feature silently non-functional for any code path using it. The NAT traversal mechanism is minimal (no actual hole-punching), HMAC key derivation is weak (SHA1 of AES key), and there is no re-probing after failure. Despite these issues, the feature gracefully degrades to TCP on failure and does not impact the primary data path.
+
+---
+
+## Architecture Context
+
+```
+Auth negotation:
+  Client → Server: support_bulk_on_rudp=true, bulk keys
+  Server → Client: use_udp_acceleration=true, port, echo keys
+
+If enabled:
+┌─────────────────────┐
+│  UdpAccelEngine      │
+│  State: idle→probing │
+│         →established │
+│         →failed      │
+├─────────────────────┤
+│  AES-128-CBC +       │
+│  HMAC-SHA1           │
+│  Per-packet:         │
+│  [flags|IV|ct|HMAC]  │
+└─────────┬───────────┘
+          │
+┌─────────▼───────────┐
+│  Data Loop:          │
+│  Outbound: try UDP   │
+│           → TCP on fail │
+│  Inbound: UDP recv   │
+│           → eth frame   │
+└─────────────────────┘
+```
+
+The UDP acceleration uses **AES-128-CBC** (not the session's AES-256-CBC) with HMAC-SHA1 integrity checks. Packets have a fixed overhead: 1 byte flags + 16 bytes IV + ciphertext + 20 bytes HMAC = 37 bytes per packet.
+
+---
+
+## Root Causes
+
+### Bug #1: `performHandshake()` passes `null` for bulk_keys
+
+**File:** `src/protocol/softether_protocol.zig:1359`  
+**Severity:** High (feature non-functional for some callers)
+
+```zig
+try buildPasswordAuth(allocator, username, pwd, hub_name, &hello.random,
+    0, "", udp_accel, null, default_opts); // ← null for bulk_keys
+```
+
+The high-level `performHandshake()` function always passes `null` for the `bulk_keys` parameter, even when `udp_accel=true`. The `buildPasswordAuth()` function (and all other auth builders) only add the bulk key exchange fields when `bulk_keys != null`:
+
+```zig
+if (opts.bulk_keys) |keys| {
+    try auth_pack.addUdpAccelFields(pack_ref, keys);
+}
+```
+
+Since bulk_keys is null, the bulk key fields (`use_udp_acceleration`, `bulk_on_rudp_send_key`, `bulk_on_rudp_recv_key`) are NEVER sent in the auth pack when using `performHandshake()`. The server sees no keys, cannot enable UDP acceleration, and responds with `use_udp_acceleration=false`.
+
+**Impact:** Any code path that uses `performHandshake()` for authentication will never establish UDP acceleration, even when explicitly requested. The feature silently doesn't work.
+
+**Contrast:** The `auth_handler.run()` path (used by `VpnClient`) correctly generates `UdpBulkKeys`, stores them in `client.bulk_keys`, and the auth builders include them. So the main `VpnClient` path IS functional, but the convenience helper is broken for any external consumer.
+
+---
+
+### Bug #2: Minimal NAT Traversal (no actual hole-punching)
+
+**File:** `src/net/udp_accel.zig` — `sendProbe()`  
+**Severity:** Medium (fails on symmetric NATs)
+
+The NAT-T probe is minimal:
+
+```zig
+fn sendProbe(self: *UdpAccelEngine) !void {
+    var buf: [16]u8 = undefined;
+    buf[0] = FLAG_NATT_PROBE; // 0x04
+    std.crypto.random.bytes(buf[1..]);
+    _ = try self.socket.sendTo(self.server_addr, &buf);
+}
+```
+
+There is no:
+- **STUN-style address discovery** (no `xor-mapped-address` to learn public IP:port)
+- **Port prediction** (no sequence of probes to predict NAT port allocation)
+- **Differential behavior** for Full Cone vs Restricted vs Symmetric NATs
+- **Retry with different ports** on probe failure
+
+The implementation simply sends a probe and waits for any response. This works for Full Cone NATs (any response accepted) and may work for Restricted Cone, but will fail for Symmetric NATs where the server's source port changes and doesn't match what the NAT expects.
+
+---
+
+### Bug #3: Weak HMAC Key Derivation
+
+**File:** `src/client/auth_handler.zig:491-492`  
+**Severity:** Medium (security)
+
+```zig
+std.crypto.hash.Sha1.hash(&send_key, &send_hmac, .{});
+std.crypto.hash.Sha1.hash(&recv_key, &recv_hmac, .{});
+```
+
+HMAC keys are derived by SHA-1 hashing the AES bulk keys. If an attacker recovers the AES key (e.g., through a side channel), the HMAC key is immediately known and forged packets can be injected into the UDP stream.
+
+A proper construction would use independent random HMAC keys or a KDF (HKDF-Expand with separate labels).
+
+---
+
+### Bug #4: No Re-Probing After Failure
+
+**File:** `src/net/udp_accel.zig` — `tick()`  
+**Severity:** Medium (permanent UDP loss)
+
+Once the engine transitions to `.failed` state, it never returns to `.probing`. There is no mechanism to re-probe and re-establish the UDP path if the network recovers (e.g., after a temporary NAT timeout). The only way to re-enable UDP acceleration is to tear down and re-establish the entire VPN connection.
+
+---
+
+### Bug #5: No Congestion Control or Packet Recovery
+
+**File:** `src/net/udp_accel.zig` — `checkSeq()`  
+**Severity:** Medium (packet loss sensitivity)
+
+```zig
+fn checkSeq(self: *UdpAccelEngine, seq: u32) bool {
+    const gap = seq -| self.last_seq;
+    if (gap > MAX_SEQ_GAP) return false; // MAX_SEQ_GAP = 16384
+    self.last_seq = seq;
+    return true;
+}
+```
+
+The only packet handling is a sequence gap check (rejects packets > 16384 seq numbers out of order). There is no:
+- **Retransmission** (lost packets are never re-sent)
+- **ACK mechanism** (no feedback about what was received)
+- **Congestion control** (sends at application's pace, no rate limiting)
+- **FEC** (no forward error correction)
+- **Reorder buffer** (out-of-order packets within 16384 window are passed through, potentially causing higher-level reordering)
+
+The UDP channel is effectively "best effort" with simple integrity checks. The SoftEther protocol relies on the TCP-on-VPN layer to handle retransmission, which creates an outer TCP-over-UDP-over-TCP stack with potentially pathological interactions.
+
+---
+
+### Bug #6: No UDP in Standalone Test Sources
+
+**File:** `build.zig:469-490`  
+**Severity:** Low (test coverage gap)
+
+```
+test_sources = .{
+    "src/net/tls.zig",
+    ...
+    "src/net/udp_accel.zig", ← NOT listed
+    ...
+};
+```
+
+The `udp_accel.zig` unit tests are NOT in the standalone `test_sources` list. They only run through the `all_test` step (if imported transitively). This means running `zig build test -- udp` won't find them, reducing the likelihood that regressions are caught.
+
+---
+
+### Bug #7: AES-128 vs AES-256 Confusion
+
+**File:** `src/net/udp_accel.zig`, `src/crypto/cipher.zig`  
+**Severity:** Low (works correctly but worth documenting)
+
+| Layer | Cipher | Key size |
+|-------|--------|----------|
+| TCP session | AES-256-CBC | 32 bytes |
+| UDP acceleration | AES-128-CBC | 16 bytes |
+| TLS transport | AES-128/256-GCM | negotiated |
+
+The UDP accel uses AES-128-CBC while the TCP session uses AES-256-CBC. This is consistent with the SoftEther protocol specification but creates potential confusion for maintainers. Both use different key material:
+- UDP bulk keys: randomly generated 16-byte keys exchanged during auth
+- TCP session keys: derived via SHA-256 from password hash + server challenge
+
+---
+
+### Bug #8: Fixed Buffer Size for UDP Payload
+
+**File:** `src/net/udp_accel.zig` — `MAX_UDP_PAYLOAD`  
+**Severity:** Low (packets > 1472 bytes silently dropped)
+
+```
+const MAX_UDP_PAYLOAD = 1472; // 1500 - 28 (IP+UDP headers)
+```
+
+The encrypt and decrypt buffers are fixed at this size. Any Ethernet frame larger than 1472 bytes (the tunnel's MTU minus IP+UDP headers) will overflow and be silently dropped. The TCP fallback in the data loop handles these packets, so no data is lost, but the UDP offload ratio decreases with larger packets.
+
+---
+
+## Detection
+
+UDP acceleration issues manifest as:
+- **No UDP traffic** even when `udp_acceleration=true` is configured
+- **Diagnostic:** Check if `use_udp_acceleration=true` appears in server auth response
+- **Latency spikes** when a NAT binding times out and the engine transitions to `.failed`
+- **Static `probing` state** never transitions — NAT is likely symmetric
+
+DIAG metrics:
+```
+Look for udp_accel.enabled or udp_readable in log
+Check bulk_on_rudp fields in auth exchange
+Monitor engine state transitions if logged
+```
+
+---
+
+## Lessons Learned
+
+### 1. Convenience functions must not silently omit critical features
+`performHandshake()` should either:
+- Accept and forward `bulk_keys` parameter
+- Or document that UDP acceleration is not supported through this path
+
+### 2. NAT traversal requires proper hole-punching
+Minimal "send and wait" probing only works for Full Cone NATs. A production-quality implementation needs STUN-style address discovery or at least port prediction.
+
+### 3. Independent key material for separate security layers
+HMAC keys derived from AES keys provide no defense-in-depth. If the AES key is compromised, both confidentiality and integrity are lost.
+
+---
+
+## Prevention Checklist
+
+- [ ] Auth helper functions pass through all optional features (bulk_keys, etc.)
+- [ ] NAT-T probing includes address discovery for symmetric NAT detection
+- [ ] HMAC keys are independent random values, not derived from encryption keys
+- [ ] Engine supports re-probing after failure (periodic retry)
+- [ ] Test sources include all modules with unit tests
+- [ ] Fixed buffer limits are documented and enforced with clear drop counters
+- [ ] No reordering of UDP packets without sequence-number-based reorder buffer
+
+---
+
+## References
+
+- `src/net/udp_accel.zig` — Full engine (646 lines, 10 unit tests)
+- `src/protocol/softether_protocol.zig` — Auth negotiation fields
+- `src/client/auth_handler.zig` — `startUdpAcceleration()` (lines 483-517)
+- `src/crypto/cipher.zig` — AES-CBC implementation
+- `build.zig:469-490` — Test sources
+- `SoftEtherVPN/src/Cedar/UdpAccel.c` — Reference C implementation (full file)
+- `SoftEtherVPN/src/Mayaqua/Network.c` — RUDP retransmission + NAT-T (full file)
+- `SoftEtherVPN/src/Mayaqua/Network.h` — RUDP constants (`RUDP_RESEND_TIMER`, `UDP_NAT_T_*`)
+- `SoftEtherVPN/src/Cedar/Protocol.c` — Bulk key exchange in Welcome pack (lines 6529-6551)
+- SCOPE.md RCA-03
+
+---
+
+## Cross-Validation Against C Source
+
+After writing this RCA, the Zig implementation was validated against the reference C source at `SoftEtherVPN/src/Cedar/` and `SoftEtherVPN/src/Mayaqua/`. Five significant discrepancies were found:
+
+### Discrepancy #1: Cipher Algorithm (RC4/ChaCha20 vs AES-128-CBC)
+
+**RCA Claim:** Uses AES-128-CBC for UDP bulk data.
+
+**Actual C behavior:**
+
+| Version | C Cipher | C Key Size | Zig Cipher | Impact |
+|---------|----------|------------|------------|--------|
+| V1 | **RC4** (NewCrypt/Encrypt) | 20 bytes (SHA1_SIZE) | AES-128-CBC | ⚠️ WRONG — incompatible cipher |
+| V2 | **ChaCha20-Poly1305** (AEAD) | 128 bytes | Not implemented | ❌ MISSING — no V2 support |
+
+V1 RC4 (`UdpAccel.c:588-591`):
+```c
+c = NewCrypt(key, UDP_ACCELERATION_PACKET_KEY_SIZE_V1);  // RC4 key (20 bytes)
+Encrypt(c, tmp + ..., tmp + ..., size - ...);              // RC4 encrypt
+FreeCrypt(c);
+```
+
+V2 ChaCha20-Poly1305 (`UdpAccel.c:547-556`):
+```c
+Aead_ChaCha20Poly1305_Ietf_Encrypt(tmp + UDP_ACCELERATION_PACKET_IV_SIZE_V2,
+    tmp + ..., size - ..., a->MyKey_V2, a->NextIv_V2, NULL, 0);
+```
+
+The Zig implementation uses AES-128-CBC (16 bytes key) which is neither the V1 RC4 (20 bytes key) nor the V2 ChaCha20-Poly1305 (128 bytes key) used by the C source. This means the Zig UDP acceleration is **wire-incompatible** with a standard SoftEther server.
+
+### Discrepancy #2: NAT-T Re-Probing
+
+**RCA Claim:** "No re-probing after failure."
+
+**Actual C behavior:** The C source has exponential backoff re-probing (`UdpAccel.c:289-333`):
+```c
+a->CommToNatT_NumFail++;
+rand_interval = UDP_NAT_T_INTERVAL_INITIAL * MIN(a->CommToNatT_NumFail, UDP_NAT_T_INTERVAL_FAIL_MAX);
+// 3s initial, 3s*60=180s max exponential backoff
+a->NextPerformNatTTick = a->Now + (UINT64)rand_interval;
+```
+
+After success, periodic re-probing at 5-10 minute intervals:
+```c
+// UDP_NAT_T_INTERVAL_MIN = 5 min, UDP_NAT_T_INTERVAL_MAX = 10 min
+rand_interval = GenRandInterval(UDP_NAT_T_INTERVAL_MIN, UDP_NAT_T_INTERVAL_MAX);
+```
+
+The Zig implementation has no re-probing after the initial probe fails or after establishment.
+
+### Discrepancy #3: RUDP Retransmission and Congestion Control
+
+**RCA Claim:** "No congestion control or retransmission."
+
+**Actual C behavior:** The C source has a FULL retransmission engine in `Network.c:2667-2698`:
+- Segment-based send list with sequence numbers
+- RTT measurement (`CurrentRtt = Now - LatestRecvMyTick`)
+- Exponential backoff: `next_interval = RTT * 120% * 2^NumSent`, capped at 4792ms
+- ACK processing: cumulative ACK removes acknowledged segments
+- Window: `RUDP_MAX_NUM_ACK = 64` segments
+
+The Zig implementation has none of this — UDP packets are fire-and-forget with only sequence gap detection.
+
+### Discrepancy #4: Bulk Key Exchange
+
+**RCA Claim:** `performHandshake()` passes null bulk_keys (feature is silently non-functional).
+
+**Actual C behavior:** The C source ALWAYS exchanges bulk keys through the Welcome pack if both sides support it (`Protocol.c:6529-6551`):
+```c
+if (s->EnableBulkOnRUDP)
+{
+    PackAddBool(p, "enable_bulk_on_rudp", true);
+    PackAddData(p, "bulk_on_rudp_send_key", ..., size);
+    PackAddData(p, "bulk_on_rudp_recv_key", ..., size);
+}
+```
+
+There is no code path where bulk keys are null when bulk is enabled. The Zig `performHandshake()` function that passes `null` for bulk_keys has NO equivalent in C — the C auth path always includes keys.
+
+### Discrepancy #5: `rudp_bulk_version` Negotiation
+
+**RCA Claim:** Not mentioned — the RCA missed version negotiation entirely.
+
+**Actual C behavior:** The protocol negotiates RUDP bulk version:
+- Client sends `rudp_bulk_max_version` (2 if supported)
+- Server responds with `rudp_bulk_version` (clamped to min of both)
+- V1: 20-byte keys, RC4 per-packet encryption, SHA-1 HMAC
+- V2: 32-byte keys, ChaCha20-Poly1305 AEAD (no separate HMAC), 12-byte IV, 16-byte MAC
+
+The Zig implementation doesn't implement V2 at all and uses the wrong cipher (AES-128-CBC vs RC4) for V1.
+
+### Implications for Zig Implementation
+
+| Aspect | Zig | C Reference | Action Needed |
+|--------|-----|-------------|---------------|
+| V1 cipher | AES-128-CBC (16B key) | **RC4** (20B key) | Fix cipher to match C for server compatibility |
+| V2 support | ❌ None | ✅ ChaCha20-Poly1305 | Implement V2 for security + performance |
+| NAT-T re-probing | ❌ None | ✅ Exponential backoff + periodic refresh | Add re-probing with backoff |
+| RUDP retransmission | ❌ None | ✅ Full segment ACK + RTT-based backoff | Implement RUDP reliability layer |
+| Bulk key exchange | `performHandshake()` passes null | ✅ Always included in Welcome pack | Fix key exchange path |
+| Version negotiation | Partial (sends max_version) | ✅ Full clamping and capability detection | Verify server response handling |
+
+

--- a/src/app/config.zig
+++ b/src/app/config.zig
@@ -6,7 +6,7 @@ const std = @import("std");
 
 const cli = @import("../cli/mod.zig");
 const client = @import("../client/mod.zig");
-const tls = @import("../net/tls.zig");
+const tls = @import("../mayaqua/network/tls.zig");
 
 pub const ConfigBuildError = error{
     MissingServer,

--- a/src/app/password_hash.zig
+++ b/src/app/password_hash.zig
@@ -5,7 +5,7 @@
 const std = @import("std");
 
 const cli = @import("../cli/mod.zig");
-const crypto = @import("../crypto/crypto.zig");
+const crypto = @import("../mayaqua/encrypt/crypto.zig");
 
 /// Generate a SoftEther password hash and print it
 pub fn generate(user: []const u8, pass: []const u8) void {

--- a/src/client/auth_handler.zig
+++ b/src/client/auth_handler.zig
@@ -13,11 +13,11 @@
 const std = @import("std");
 const net = std.net;
 
-const tls = @import("../net/net.zig").tls;
+const tls = @import("../mayaqua/network/net.zig").tls;
 const softether_proto = @import("../protocol/softether_protocol.zig");
 const pack_mod = @import("../protocol/pack.zig");
-const udp_accel_mod = @import("../net/udp_accel.zig");
-const core = @import("../core/mod.zig");
+const udp_accel_mod = @import("../mayaqua/network/udp_accel.zig");
+const core = @import("../mayaqua/kernel/mod.zig");
 const formatAddress = core.formatAddressForHost;
 
 const vpn_client = @import("vpn_client.zig");

--- a/src/client/connection_manager.zig
+++ b/src/client/connection_manager.zig
@@ -8,7 +8,7 @@ const std = @import("std");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 
-const tls = @import("../net/tls.zig");
+const tls = @import("../mayaqua/network/tls.zig");
 const protocol_tunnel = @import("../protocol/tunnel.zig");
 const TunnelConnection = protocol_tunnel.TunnelConnection;
 

--- a/src/client/session_setup.zig
+++ b/src/client/session_setup.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 
-const tls = @import("../net/net.zig").tls;
+const tls = @import("../mayaqua/network/net.zig").tls;
 const softether_proto = @import("../protocol/softether_protocol.zig");
-const core = @import("../core/mod.zig");
+const core = @import("../mayaqua/kernel/mod.zig");
 const formatAddress = core.formatAddressForHost;
 
 const vpn_client = @import("vpn_client.zig");

--- a/src/client/vpn_client.zig
+++ b/src/client/vpn_client.zig
@@ -19,7 +19,7 @@ const builtin = @import("builtin");
 const net = std.net;
 
 // Import core utilities
-const core = @import("../core/mod.zig");
+const core = @import("../mayaqua/kernel/mod.zig");
 const parseIpv4 = core.parseIpv4;
 
 // Import extracted client modules
@@ -35,7 +35,7 @@ pub const ClientError = events_mod.ClientError;
 pub const EventCallback = events_mod.EventCallback;
 
 // Import real networking modules
-const net_mod = @import("../net/net.zig");
+const net_mod = @import("../mayaqua/network/net.zig");
 
 const tls = net_mod.tls;
 
@@ -56,7 +56,7 @@ const softether_proto = @import("../protocol/softether_protocol.zig");
 const protocol_tunnel_mod = @import("../protocol/tunnel.zig");
 
 // Import UDP acceleration
-const udp_accel_mod = @import("../net/udp_accel.zig");
+const udp_accel_mod = @import("../mayaqua/network/udp_accel.zig");
 
 // Import tunnel module (data loop helpers)
 const tunnel_mod = @import("../tunnel/mod.zig");

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -535,7 +535,7 @@ export fn softether_set_verify_certificate(client: ?*VpnClient, verify: bool) vo
 /// tunnel that's not yet established → instant ECONNREFUSED.
 /// Pass NULL or "" to clear.
 export fn softether_set_bind_interface(name: ?[*:0]const u8) void {
-    const tls = @import("net/tls.zig");
+    const tls = @import("mayaqua/network/tls.zig");
     if (name == null) {
         tls.bind_interface_index = 0;
         return;
@@ -565,7 +565,7 @@ export fn softether_set_bind_interface(name: ?[*:0]const u8) void {
 /// Used on iOS NEPacketTunnelProvider where the extension's own POSIX
 /// connect() is denied by NECP — Swift dials via NEProvider.createTCPConnection
 /// (which goes outside the tunnel) and bridges bytes through a socketpair.
-const tls_mod = @import("net/tls.zig");
+const tls_mod = @import("mayaqua/network/tls.zig");
 
 export fn softether_set_tcp_dial_callback(cb: ?tls_mod.ExternalTcpDialFn) void {
     tls_mod.external_tcp_dial = cb;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -71,7 +71,7 @@ pub const ReconnectConfig = @import("client/mod.zig").ReconnectConfig;
 // ============================================================================
 
 /// Core utilities (IP parsing, etc.)
-pub const core = @import("core/mod.zig");
+pub const core = @import("mayaqua/kernel/mod.zig");
 
 /// Parse an IPv4 address string to u32
 pub const parseIpv4 = core.parseIpv4;

--- a/src/mayaqua/encrypt/cipher.zig
+++ b/src/mayaqua/encrypt/cipher.zig
@@ -1,0 +1,331 @@
+//! Symmetric Encryption Module
+//!
+//! AES encryption for SoftEther VPN data channels.
+//!
+//! # SECURITY NOTE — Unauthenticated AES-CBC
+//!
+//! The AES-CBC implementations in this module provide **confidentiality only**.
+//! There is no MAC / integrity tag — ciphertexts can be silently tampered with
+//! by an active attacker. This is by SoftEther protocol design: the data
+//! channel runs over TLS 1.2+, which provides transport-layer integrity.
+//!
+//! Do NOT use these AES-CBC primitives outside the SoftEther data channel
+//! unless you also add a separate MAC (e.g. HMAC-SHA256 Encrypt-then-MAC).
+//! For general-purpose encryption, prefer AES-GCM (`Aes128Gcm` / `Aes256Gcm`)
+//! which provides authenticated encryption.
+
+const std = @import("std");
+const crypto = std.crypto;
+const testing = std.testing;
+
+/// AES block size (always 16 bytes)
+pub const block_size = 16;
+
+// ============================================================================
+// AES-CBC mode (used by SoftEther for some operations)
+// ============================================================================
+
+/// AES-128-CBC encryption — manual implementation, **unauthenticated**.
+///
+/// SECURITY: CBC mode provides no integrity verification. A passive attacker
+/// can decrypt, an active attacker can flip bits in plaintext (padding oracle
+/// risks if errors are distinguishable). NOT suitable outside the SoftEther
+/// data channel without an outer MAC.
+pub const Aes128Cbc = struct {
+    const Self = @This();
+    const Aes128 = crypto.core.aes.Aes128;
+
+    key: [16]u8,
+    iv: [block_size]u8,
+
+    pub fn init(key: *const [16]u8, iv: *const [block_size]u8) Self {
+        return .{
+            .key = key.*,
+            .iv = iv.*,
+        };
+    }
+
+    /// Encrypt data in-place (must be multiple of block_size)
+    pub fn encrypt(self: *Self, data: []u8) !void {
+        if (data.len == 0) return;
+        if (data.len % block_size != 0) return error.InvalidBlockSize;
+
+        const enc = Aes128.initEnc(self.key);
+        var prev: [block_size]u8 = self.iv;
+        var i: usize = 0;
+
+        while (i < data.len) : (i += block_size) {
+            const block_ptr = data[i..][0..block_size];
+
+            // XOR with previous ciphertext (or IV for first block)
+            for (0..block_size) |j| {
+                block_ptr[j] ^= prev[j];
+            }
+
+            // Encrypt
+            enc.encrypt(block_ptr, block_ptr);
+            prev = block_ptr.*;
+        }
+
+        // Update IV for next operation
+        self.iv = prev;
+    }
+
+    /// Decrypt data in-place (must be multiple of block_size)
+    pub fn decrypt(self: *Self, data: []u8) !void {
+        if (data.len == 0) return;
+        if (data.len % block_size != 0) return error.InvalidBlockSize;
+
+        const dec = Aes128.initDec(self.key);
+        var prev: [block_size]u8 = self.iv;
+        var i: usize = 0;
+
+        while (i < data.len) : (i += block_size) {
+            const block_ptr = data[i..][0..block_size];
+            const temp: [block_size]u8 = block_ptr.*;
+
+            // Decrypt
+            dec.decrypt(block_ptr, block_ptr);
+
+            // XOR with previous ciphertext (or IV for first block)
+            for (0..block_size) |j| {
+                block_ptr[j] ^= prev[j];
+            }
+
+            prev = temp;
+        }
+
+        // Update IV for next operation
+        self.iv = prev;
+    }
+};
+
+/// AES-256-CBC encryption — manual implementation, **unauthenticated**.
+///
+/// SECURITY: Same caveats as Aes128Cbc. Used by the SoftEther session layer
+/// for data channel encryption. Integrity is expected from the TLS transport.
+pub const Aes256Cbc = struct {
+    const Self = @This();
+    const Aes256 = crypto.core.aes.Aes256;
+
+    key: [32]u8,
+    iv: [block_size]u8,
+
+    pub fn init(key: *const [32]u8, iv: *const [block_size]u8) Self {
+        return .{
+            .key = key.*,
+            .iv = iv.*,
+        };
+    }
+
+    /// Encrypt data in-place (must be multiple of block_size)
+    pub fn encrypt(self: *Self, data: []u8) !void {
+        if (data.len == 0) return;
+        if (data.len % block_size != 0) return error.InvalidBlockSize;
+
+        const enc = Aes256.initEnc(self.key);
+        var prev: [block_size]u8 = self.iv;
+        var i: usize = 0;
+
+        while (i < data.len) : (i += block_size) {
+            const block_ptr = data[i..][0..block_size];
+
+            for (0..block_size) |j| {
+                block_ptr[j] ^= prev[j];
+            }
+
+            enc.encrypt(block_ptr, block_ptr);
+            prev = block_ptr.*;
+        }
+
+        self.iv = prev;
+    }
+
+    /// Decrypt data in-place (must be multiple of block_size)
+    pub fn decrypt(self: *Self, data: []u8) !void {
+        if (data.len == 0) return;
+        if (data.len % block_size != 0) return error.InvalidBlockSize;
+
+        const dec = Aes256.initDec(self.key);
+        var prev: [block_size]u8 = self.iv;
+        var i: usize = 0;
+
+        while (i < data.len) : (i += block_size) {
+            const block_ptr = data[i..][0..block_size];
+            const temp: [block_size]u8 = block_ptr.*;
+
+            dec.decrypt(block_ptr, block_ptr);
+
+            for (0..block_size) |j| {
+                block_ptr[j] ^= prev[j];
+            }
+
+            prev = temp;
+        }
+
+        self.iv = prev;
+    }
+};
+
+// ============================================================================
+// PKCS7 padding
+// ============================================================================
+
+/// Add PKCS7 padding
+pub fn pkcs7Pad(data: []const u8, output: []u8) ![]u8 {
+    const padded_len = ((data.len / block_size) + 1) * block_size;
+    if (output.len < padded_len) return error.BufferTooSmall;
+
+    @memcpy(output[0..data.len], data);
+
+    const pad_byte: u8 = @intCast(padded_len - data.len);
+    @memset(output[data.len..padded_len], pad_byte);
+
+    return output[0..padded_len];
+}
+
+/// Remove PKCS7 padding
+pub fn pkcs7Unpad(data: []u8) ![]u8 {
+    if (data.len == 0 or data.len % block_size != 0) {
+        return error.InvalidPadding;
+    }
+
+    const pad_byte = data[data.len - 1];
+    if (pad_byte == 0 or pad_byte > block_size) {
+        return error.InvalidPadding;
+    }
+
+    // Verify all padding bytes
+    const pad_len: usize = @intCast(pad_byte);
+    for (data[data.len - pad_len ..]) |b| {
+        if (b != pad_byte) return error.InvalidPadding;
+    }
+
+    return data[0 .. data.len - pad_len];
+}
+
+// ============================================================================
+// AES-GCM (authenticated encryption)
+// ============================================================================
+
+pub const Aes128Gcm = crypto.aead.aes_gcm.Aes128Gcm;
+pub const Aes256Gcm = crypto.aead.aes_gcm.Aes256Gcm;
+
+/// Encrypt with AES-128-GCM
+pub fn aes128GcmEncrypt(
+    plaintext: []const u8,
+    additional_data: []const u8,
+    key: *const [16]u8,
+    nonce: *const [12]u8,
+    ciphertext: []u8,
+    tag: *[16]u8,
+) void {
+    Aes128Gcm.encrypt(ciphertext, tag, plaintext, additional_data, nonce.*, key.*);
+}
+
+/// Decrypt with AES-128-GCM
+pub fn aes128GcmDecrypt(
+    ciphertext: []const u8,
+    additional_data: []const u8,
+    key: *const [16]u8,
+    nonce: *const [12]u8,
+    tag: *const [16]u8,
+    plaintext: []u8,
+) !void {
+    Aes128Gcm.decrypt(plaintext, ciphertext, tag.*, additional_data, nonce.*, key.*) catch {
+        return error.AuthenticationFailed;
+    };
+}
+
+// ============================================================================
+// ChaCha20-Poly1305 (alternative to AES-GCM)
+// ============================================================================
+
+pub const ChaCha20Poly1305 = crypto.aead.chacha_poly.ChaCha20Poly1305;
+
+// ============================================================================
+// Random number generation
+// ============================================================================
+
+/// Generate cryptographically secure random bytes
+pub fn randomBytes(buffer: []u8) void {
+    crypto.random.bytes(buffer);
+}
+
+/// Generate random u32
+pub fn randomU32() u32 {
+    return crypto.random.int(u32);
+}
+
+/// Generate random u64
+pub fn randomU64() u64 {
+    return crypto.random.int(u64);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "AES-128-CBC encrypt/decrypt" {
+    const key = [_]u8{0x00} ** 16;
+    const iv = [_]u8{0x00} ** 16;
+
+    var cbc = Aes128Cbc.init(&key, &iv);
+
+    // Test data (must be block-aligned)
+    var data = [_]u8{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+    const original = data;
+
+    try cbc.encrypt(&data);
+    try testing.expect(!std.mem.eql(u8, &data, &original));
+
+    // Reset IV for decryption
+    cbc.iv = iv;
+    try cbc.decrypt(&data);
+    try testing.expectEqualSlices(u8, &original, &data);
+}
+
+test "PKCS7 padding" {
+    const data = "Hello";
+    var output: [16]u8 = undefined;
+
+    const padded = try pkcs7Pad(data, &output);
+    try testing.expectEqual(@as(usize, 16), padded.len);
+
+    // Last byte should be the pad length (11)
+    try testing.expectEqual(@as(u8, 11), padded[15]);
+
+    var padded_mut: [16]u8 = undefined;
+    @memcpy(&padded_mut, padded);
+
+    const unpadded = try pkcs7Unpad(&padded_mut);
+    try testing.expectEqualStrings(data, unpadded);
+}
+
+test "AES-128-GCM encrypt/decrypt" {
+    const key = [_]u8{0x00} ** 16;
+    const nonce = [_]u8{0x00} ** 12;
+    const plaintext = "Hello, World!";
+    const aad = "additional data";
+
+    var ciphertext: [plaintext.len]u8 = undefined;
+    var tag: [16]u8 = undefined;
+
+    aes128GcmEncrypt(plaintext, aad, &key, &nonce, &ciphertext, &tag);
+
+    var decrypted: [plaintext.len]u8 = undefined;
+    try aes128GcmDecrypt(&ciphertext, aad, &key, &nonce, &tag, &decrypted);
+
+    try testing.expectEqualStrings(plaintext, &decrypted);
+}
+
+test "random bytes" {
+    var buf1: [32]u8 = undefined;
+    var buf2: [32]u8 = undefined;
+
+    randomBytes(&buf1);
+    randomBytes(&buf2);
+
+    // Extremely unlikely to be equal
+    try testing.expect(!std.mem.eql(u8, &buf1, &buf2));
+}

--- a/src/mayaqua/encrypt/crypto.zig
+++ b/src/mayaqua/encrypt/crypto.zig
@@ -1,0 +1,56 @@
+//! SoftEther VPN Cryptography Library
+//!
+//! This module provides cryptographic primitives.
+//! Phase 3 of the C-to-Zig migration.
+
+pub const sha0 = @import("sha0.zig");
+pub const hash = @import("hash.zig");
+pub const cipher = @import("cipher.zig");
+
+// Re-export commonly used types and functions
+
+// SHA-0 (SoftEther-specific)
+pub const Sha0 = sha0.Sha0;
+pub const sha0Hash = sha0.hash;
+pub const softEtherPasswordHash = sha0.softEtherPasswordHash;
+pub const softEtherSecurePassword = sha0.softEtherSecurePassword;
+
+// Standard hashes
+pub const Sha1 = hash.Sha1;
+pub const Sha256 = hash.Sha256;
+pub const Sha512 = hash.Sha512;
+pub const Md5 = hash.Md5;
+pub const sha1 = hash.sha1;
+pub const sha256 = hash.sha256;
+pub const sha512 = hash.sha512;
+pub const md5 = hash.md5;
+
+// HMAC
+pub const HmacSha1 = hash.HmacSha1;
+pub const HmacSha256 = hash.HmacSha256;
+pub const hmacSha1 = hash.hmacSha1;
+pub const hmacSha256 = hash.hmacSha256;
+
+// Symmetric encryption
+pub const Aes128Cbc = cipher.Aes128Cbc;
+pub const Aes256Cbc = cipher.Aes256Cbc;
+pub const Aes128Gcm = cipher.Aes128Gcm;
+pub const Aes256Gcm = cipher.Aes256Gcm;
+pub const ChaCha20Poly1305 = cipher.ChaCha20Poly1305;
+
+// Utilities
+pub const randomBytes = cipher.randomBytes;
+pub const randomU32 = cipher.randomU32;
+pub const randomU64 = cipher.randomU64;
+pub const constTimeEql = hash.constTimeEql;
+pub const toHex = hash.toHex;
+pub const fromHex = hash.fromHex;
+
+// Padding
+pub const pkcs7Pad = cipher.pkcs7Pad;
+pub const pkcs7Unpad = cipher.pkcs7Unpad;
+
+// Tests
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/mayaqua/encrypt/hash.zig
+++ b/src/mayaqua/encrypt/hash.zig
@@ -1,0 +1,231 @@
+//! Cryptographic Hash Functions
+//!
+//! Wrappers around Zig std crypto hashes plus custom SHA-0.
+
+const std = @import("std");
+const crypto = std.crypto;
+const testing = std.testing;
+
+pub const sha0 = @import("sha0.zig");
+
+// Re-export standard hashes
+pub const Sha1 = crypto.hash.Sha1;
+pub const Sha256 = crypto.hash.sha2.Sha256;
+pub const Sha384 = crypto.hash.sha2.Sha384;
+pub const Sha512 = crypto.hash.sha2.Sha512;
+pub const Md5 = crypto.hash.Md5;
+
+test "sha1 one-shot" {
+    const input = "hello";
+    const expected = [_]u8{
+        0xaa, 0xf4, 0xc6, 0x1d, 0xdc, 0xc5, 0xe8, 0xa2,
+        0xda, 0xbe, 0xde, 0x0f, 0x3b, 0x48, 0x2c, 0xd9,
+        0xae, 0xa9, 0x43, 0x4d,
+    };
+    const result = sha1(input);
+    try testing.expectEqualSlices(u8, &expected, &result);
+}
+
+test "sha256 one-shot" {
+    const input = "hello";
+    const expected = [_]u8{
+        0x2c, 0xf2, 0x4d, 0xba, 0x5f, 0xb0, 0xa3, 0x0e,
+        0x26, 0xe8, 0x3b, 0x2a, 0xc5, 0xb9, 0xe2, 0x9e,
+        0x1b, 0x16, 0x1e, 0x5c, 0x1f, 0xa7, 0x42, 0x5e,
+        0x73, 0x04, 0x33, 0x62, 0x93, 0x8b, 0x98, 0x24,
+    };
+    const result = sha256(input);
+    try testing.expectEqualSlices(u8, &expected, &result);
+}
+
+test "sha512 one-shot" {
+    const input = "hello";
+    const expected = [_]u8{
+        0x9b, 0x71, 0xd2, 0x24, 0xbd, 0x62, 0xf3, 0x78,
+        0x5d, 0x96, 0xd4, 0x6a, 0xd3, 0xea, 0x3d, 0x73,
+        0x31, 0x9b, 0xfb, 0xc2, 0x89, 0x0c, 0xaa, 0xda,
+        0xe2, 0xdf, 0xf7, 0x25, 0x19, 0x67, 0x3c, 0xa7,
+        0x23, 0x23, 0xc3, 0xd9, 0x9b, 0xa5, 0xc1, 0x1d,
+        0x7c, 0x7a, 0xcc, 0x6e, 0x14, 0xb8, 0xc5, 0xda,
+        0x0c, 0x46, 0x63, 0x47, 0x5c, 0x2e, 0x5c, 0x3a,
+        0xde, 0xf4, 0x6f, 0x73, 0xbc, 0xde, 0xc0, 0x43,
+    };
+    const result = sha512(input);
+    try testing.expectEqualSlices(u8, &expected, &result);
+}
+
+test "md5 one-shot" {
+    const input = "hello";
+    const expected = [_]u8{
+        0x5d, 0x41, 0x40, 0x2a, 0xbc, 0x4b, 0x2a, 0x76,
+        0xb9, 0x71, 0x9d, 0x91, 0x10, 0x17, 0xc5, 0x92,
+    };
+    const result = md5(input);
+    try testing.expectEqualSlices(u8, &expected, &result);
+}
+
+/// SHA-1 one-shot hash
+pub fn sha1(data: []const u8) [20]u8 {
+    var out: [20]u8 = undefined;
+    Sha1.hash(data, &out, .{});
+    return out;
+}
+
+/// SHA-256 one-shot hash
+pub fn sha256(data: []const u8) [32]u8 {
+    var out: [32]u8 = undefined;
+    Sha256.hash(data, &out, .{});
+    return out;
+}
+
+/// SHA-512 one-shot hash
+pub fn sha512(data: []const u8) [64]u8 {
+    var out: [64]u8 = undefined;
+    Sha512.hash(data, &out, .{});
+    return out;
+}
+
+/// MD5 one-shot hash (for legacy compatibility only)
+pub fn md5(data: []const u8) [16]u8 {
+    var out: [16]u8 = undefined;
+    Md5.hash(data, &out, .{});
+    return out;
+}
+
+/// HMAC implementation
+pub fn Hmac(comptime Hash: type) type {
+    return crypto.auth.hmac.Hmac(Hash);
+}
+
+pub const HmacSha1 = Hmac(Sha1);
+pub const HmacSha256 = Hmac(Sha256);
+pub const HmacMd5 = Hmac(Md5);
+
+/// Compute HMAC-SHA1
+pub fn hmacSha1(key: []const u8, data: []const u8) [20]u8 {
+    var mac: [20]u8 = undefined;
+    HmacSha1.create(&mac, data, key);
+    return mac;
+}
+
+/// Compute HMAC-SHA256
+pub fn hmacSha256(key: []const u8, data: []const u8) [32]u8 {
+    var mac: [32]u8 = undefined;
+    HmacSha256.create(&mac, data, key);
+    return mac;
+}
+
+// ============================================================================
+// PBKDF2 for key derivation
+// ============================================================================
+
+/// PBKDF2-HMAC-SHA256
+pub fn pbkdf2Sha256(
+    password: []const u8,
+    salt: []const u8,
+    iterations: u32,
+    output: []u8,
+) void {
+    crypto.pwhash.pbkdf2(output, password, salt, iterations, .sha256);
+}
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+/// Compare two hashes in constant time (timing-safe)
+pub fn constTimeEql(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+
+    var result: u8 = 0;
+    for (a, b) |x, y| {
+        result |= x ^ y;
+    }
+    return result == 0;
+}
+
+/// Format hash as lowercase hex string
+pub fn toHex(digest: []const u8, output: []u8) []u8 {
+    const hex_chars = "0123456789abcdef";
+    for (digest, 0..) |byte, i| {
+        output[i * 2] = hex_chars[byte >> 4];
+        output[i * 2 + 1] = hex_chars[byte & 0x0f];
+    }
+    return output[0 .. digest.len * 2];
+}
+
+/// Parse hex string to bytes
+pub fn fromHex(hex: []const u8, output: []u8) ![]u8 {
+    if (hex.len % 2 != 0) return error.InvalidHexLength;
+    if (output.len < hex.len / 2) return error.BufferTooSmall;
+
+    var i: usize = 0;
+    while (i < hex.len) : (i += 2) {
+        const high = hexVal(hex[i]) orelse return error.InvalidHexChar;
+        const low = hexVal(hex[i + 1]) orelse return error.InvalidHexChar;
+        output[i / 2] = (high << 4) | low;
+    }
+
+    return output[0 .. hex.len / 2];
+}
+
+fn hexVal(c: u8) ?u8 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'a'...'f' => c - 'a' + 10,
+        'A'...'F' => c - 'A' + 10,
+        else => null,
+    };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "sha1 hash" {
+    const result = sha1("abc");
+    var hex: [40]u8 = undefined;
+    const hex_str = toHex(&result, &hex);
+    try testing.expectEqualStrings("a9993e364706816aba3e25717850c26c9cd0d89d", hex_str);
+}
+
+test "sha256 hash" {
+    const result = sha256("abc");
+    var hex: [64]u8 = undefined;
+    const hex_str = toHex(&result, &hex);
+    try testing.expectEqualStrings("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hex_str);
+}
+
+test "md5 hash" {
+    const result = md5("abc");
+    var hex: [32]u8 = undefined;
+    const hex_str = toHex(&result, &hex);
+    try testing.expectEqualStrings("900150983cd24fb0d6963f7d28e17f72", hex_str);
+}
+
+test "hmac-sha1" {
+    const mac = hmacSha1("key", "The quick brown fox jumps over the lazy dog");
+    var hex: [40]u8 = undefined;
+    const hex_str = toHex(&mac, &hex);
+    try testing.expectEqualStrings("de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9", hex_str);
+}
+
+test "constant time comparison" {
+    const a = [_]u8{ 1, 2, 3, 4 };
+    const b = [_]u8{ 1, 2, 3, 4 };
+    const c = [_]u8{ 1, 2, 3, 5 };
+
+    try testing.expect(constTimeEql(&a, &b));
+    try testing.expect(!constTimeEql(&a, &c));
+}
+
+test "hex conversion roundtrip" {
+    const original = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
+    var hex_buf: [8]u8 = undefined;
+    const hex = toHex(&original, &hex_buf);
+
+    var decoded: [4]u8 = undefined;
+    const result = try fromHex(hex, &decoded);
+
+    try testing.expectEqualSlices(u8, &original, result);
+}

--- a/src/mayaqua/encrypt/sha0.zig
+++ b/src/mayaqua/encrypt/sha0.zig
@@ -1,0 +1,267 @@
+//! SHA-0 Implementation
+//!
+//! SoftEther VPN uses SHA-0 (not SHA-1!) for password hashing.
+//! SHA-0 differs from SHA-1 only in the message schedule - no rotation.
+//! This is a critical compatibility requirement.
+//!
+//! # SECURITY WARNING — Broken Algorithm
+//!
+//! SHA-0 is cryptographically broken. Collision attacks have been publicly
+//! demonstrated since 1998 (Chabaud & Joux). Do NOT use for any purpose
+//! outside SoftEther protocol compatibility.
+//!
+//! This implementation exists solely to interoperate with existing SoftEther
+//! VPN servers that use SHA-0 in their auth handshake. It provides NO security
+//! guarantees against a motivated attacker.
+
+const std = @import("std");
+const testing = std.testing;
+
+/// SHA-0 hash output size in bytes
+pub const digest_length = 20;
+
+/// SHA-0 block size in bytes
+pub const block_length = 64;
+
+/// SHA-0 hasher state
+pub const Sha0 = struct {
+    const Self = @This();
+
+    /// Initial hash values (same as SHA-1)
+    const iv = [5]u32{
+        0x67452301,
+        0xEFCDAB89,
+        0x98BADCFE,
+        0x10325476,
+        0xC3D2E1F0,
+    };
+
+    /// Round constants
+    const k = [4]u32{
+        0x5A827999, // rounds 0-19
+        0x6ED9EBA1, // rounds 20-39
+        0x8F1BBCDC, // rounds 40-59
+        0xCA62C1D6, // rounds 60-79
+    };
+
+    state: [5]u32 = iv,
+    buf: [block_length]u8 = undefined,
+    buf_len: usize = 0,
+    total_len: u64 = 0,
+
+    pub fn init() Self {
+        return .{};
+    }
+
+    pub fn update(self: *Self, data: []const u8) void {
+        var input = data;
+
+        // Process any buffered data first
+        if (self.buf_len > 0) {
+            const space = block_length - self.buf_len;
+            const to_copy = @min(space, input.len);
+            @memcpy(self.buf[self.buf_len..][0..to_copy], input[0..to_copy]);
+            self.buf_len += to_copy;
+            input = input[to_copy..];
+
+            if (self.buf_len == block_length) {
+                self.processBlock(&self.buf);
+                self.buf_len = 0;
+            }
+        }
+
+        // Process full blocks
+        while (input.len >= block_length) {
+            self.processBlock(input[0..block_length]);
+            input = input[block_length..];
+        }
+
+        // Buffer remaining
+        if (input.len > 0) {
+            @memcpy(self.buf[0..input.len], input);
+            self.buf_len = input.len;
+        }
+
+        self.total_len += data.len;
+    }
+
+    fn processBlock(self: *Self, block: *const [block_length]u8) void {
+        var w: [80]u32 = undefined;
+
+        // Message schedule (SHA-0 differs here - no rotation!)
+        for (0..16) |i| {
+            w[i] = std.mem.readInt(u32, block[i * 4 ..][0..4], .big);
+        }
+
+        // SHA-0: XOR without rotation (this is the key difference from SHA-1)
+        for (16..80) |i| {
+            w[i] = w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16];
+            // SHA-1 would do: w[i] = rotl(w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16], 1)
+        }
+
+        var a = self.state[0];
+        var b = self.state[1];
+        var c = self.state[2];
+        var d = self.state[3];
+        var e = self.state[4];
+
+        for (0..80) |i| {
+            const f: u32 = switch (i / 20) {
+                0 => (b & c) | ((~b) & d),
+                1 => b ^ c ^ d,
+                2 => (b & c) | (b & d) | (c & d),
+                3 => b ^ c ^ d,
+                else => unreachable,
+            };
+
+            const ki = k[i / 20];
+            const temp = rotl(a, 5) +% f +% e +% ki +% w[i];
+
+            e = d;
+            d = c;
+            c = rotl(b, 30);
+            b = a;
+            a = temp;
+        }
+
+        self.state[0] +%= a;
+        self.state[1] +%= b;
+        self.state[2] +%= c;
+        self.state[3] +%= d;
+        self.state[4] +%= e;
+    }
+
+    pub fn final(self: *Self) [digest_length]u8 {
+        // Padding
+        const total_bits = self.total_len * 8;
+
+        // Add 1 bit followed by zeros
+        self.buf[self.buf_len] = 0x80;
+        self.buf_len += 1;
+
+        // If not enough space for length, process block and start new one
+        if (self.buf_len > 56) {
+            @memset(self.buf[self.buf_len..], 0);
+            self.processBlock(&self.buf);
+            self.buf_len = 0;
+        }
+
+        // Pad with zeros up to length field
+        @memset(self.buf[self.buf_len..56], 0);
+
+        // Append length in bits (big-endian)
+        std.mem.writeInt(u64, self.buf[56..64], total_bits, .big);
+        self.processBlock(&self.buf);
+
+        // Output hash
+        var result: [digest_length]u8 = undefined;
+        for (0..5) |i| {
+            std.mem.writeInt(u32, result[i * 4 ..][0..4], self.state[i], .big);
+        }
+
+        return result;
+    }
+
+    fn rotl(x: u32, comptime n: comptime_int) u32 {
+        return std.math.rotl(u32, x, n);
+    }
+};
+
+/// One-shot SHA-0 hash
+pub fn hash(data: []const u8) [digest_length]u8 {
+    var h = Sha0.init();
+    h.update(data);
+    return h.final();
+}
+
+/// Format hash as hex string
+pub fn hashToHex(digest: *const [digest_length]u8) [digest_length * 2]u8 {
+    const hex_chars = "0123456789abcdef";
+    var result: [digest_length * 2]u8 = undefined;
+
+    for (digest, 0..) |byte, i| {
+        result[i * 2] = hex_chars[byte >> 4];
+        result[i * 2 + 1] = hex_chars[byte & 0x0f];
+    }
+
+    return result;
+}
+
+// ============================================================================
+// SoftEther password hashing
+// ============================================================================
+
+/// SoftEther password hash format
+/// Hash = SHA0(password + username)
+pub fn softEtherPasswordHash(username: []const u8, password: []const u8) [digest_length]u8 {
+    var h = Sha0.init();
+    h.update(password);
+    h.update(username);
+    return h.final();
+}
+
+/// SoftEther secure password with challenge
+/// Hash = SHA0(SHA0(password + username) + challenge)
+pub fn softEtherSecurePassword(
+    username: []const u8,
+    password: []const u8,
+    challenge: []const u8,
+) [digest_length]u8 {
+    const password_hash = softEtherPasswordHash(username, password);
+    var h = Sha0.init();
+    h.update(&password_hash);
+    h.update(challenge);
+    return h.final();
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "SHA-0 empty string" {
+    const result = hash("");
+    const hex = hashToHex(&result);
+    // SHA-0("") known value
+    try testing.expectEqualStrings("f96cea198ad1dd5617ac084a3d92c6107708c0ef", &hex);
+}
+
+test "SHA-0 abc" {
+    const result = hash("abc");
+    const hex = hashToHex(&result);
+    // SHA-0("abc") known value
+    try testing.expectEqualStrings("0164b8a914cd2a5e74c4f7ff082c4d97f1edf880", &hex);
+}
+
+test "SHA-0 longer message" {
+    const msg = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    const result = hash(msg);
+    const hex = hashToHex(&result);
+    // SHA-0 known value for this message
+    try testing.expectEqualStrings("d2516ee1acfa5baf33dfc1c471e438449ef134c8", &hex);
+}
+
+test "SHA-0 incremental" {
+    var h = Sha0.init();
+    h.update("abc");
+    h.update("def");
+    const result = h.final();
+
+    const single = hash("abcdef");
+    try testing.expectEqualSlices(u8, &single, &result);
+}
+
+test "SoftEther password hash" {
+    // Test that password hashing works
+    const pw_hash = softEtherPasswordHash("testuser", "testpass");
+    try testing.expectEqual(@as(usize, 20), pw_hash.len);
+
+    // Same input should give same output
+    const pw_hash2 = softEtherPasswordHash("testuser", "testpass");
+    try testing.expectEqualSlices(u8, &pw_hash, &pw_hash2);
+}
+
+test "SoftEther secure password" {
+    const challenge = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    const secure = softEtherSecurePassword("user", "pass", &challenge);
+    try testing.expectEqual(@as(usize, 20), secure.len);
+}

--- a/src/mayaqua/kernel/errors.zig
+++ b/src/mayaqua/kernel/errors.zig
@@ -1,0 +1,79 @@
+//! Error Types
+//!
+//! Consolidated error definitions used across the codebase.
+
+const std = @import("std");
+
+/// VPN error types
+pub const VpnError = error{
+    // Initialization errors
+    InitializationFailed,
+    CleanupFailed,
+    ClientCreationFailed,
+    ConfigurationError,
+
+    // Connection errors
+    ConnectionFailed,
+    DisconnectionFailed,
+    AlreadyConnected,
+    NotConnected,
+    TimeoutError,
+
+    // Authentication errors
+    AuthenticationFailed,
+    InvalidCredentials,
+    CertificateError,
+
+    // Configuration errors
+    InvalidParameter,
+    InvalidServerAddress,
+    InvalidPort,
+    InvalidHubName,
+    MissingParameter,
+
+    // Operation errors
+    OperationFailed,
+    NotInitialized,
+    InternalError,
+    OutOfMemory,
+
+    // Network errors
+    NetworkError,
+    ProtocolError,
+    ServerUnreachable,
+};
+
+/// Get error message for VpnError
+pub fn errorMessage(err: VpnError) []const u8 {
+    return switch (err) {
+        VpnError.InitializationFailed => "Failed to initialize VPN client",
+        VpnError.CleanupFailed => "Failed to cleanup resources",
+        VpnError.ClientCreationFailed => "Failed to create client instance",
+        VpnError.ConfigurationError => "Configuration error",
+        VpnError.ConnectionFailed => "Failed to establish VPN connection",
+        VpnError.DisconnectionFailed => "Failed to disconnect",
+        VpnError.AlreadyConnected => "Already connected",
+        VpnError.NotConnected => "Not connected",
+        VpnError.TimeoutError => "Operation timed out",
+        VpnError.AuthenticationFailed => "Authentication failed",
+        VpnError.InvalidCredentials => "Invalid credentials provided",
+        VpnError.CertificateError => "Certificate validation error",
+        VpnError.InvalidParameter => "Invalid parameter",
+        VpnError.InvalidServerAddress => "Invalid server address",
+        VpnError.InvalidPort => "Invalid port number",
+        VpnError.InvalidHubName => "Invalid hub name",
+        VpnError.MissingParameter => "Required parameter is missing",
+        VpnError.OperationFailed => "Operation failed",
+        VpnError.NotInitialized => "Not initialized",
+        VpnError.InternalError => "Internal error",
+        VpnError.OutOfMemory => "Out of memory",
+        VpnError.NetworkError => "Network error occurred",
+        VpnError.ProtocolError => "VPN protocol error",
+        VpnError.ServerUnreachable => "Server unreachable",
+    };
+}
+
+test "error message lookup" {
+    try std.testing.expectEqualStrings("Already connected", errorMessage(VpnError.AlreadyConnected));
+    try std.testing.expectEqualStrings("Authentication failed", errorMessage(VpnError.AuthenticationFailed));
+}

--- a/src/mayaqua/kernel/ip.zig
+++ b/src/mayaqua/kernel/ip.zig
@@ -1,0 +1,221 @@
+//! IP Address Utilities
+//!
+//! Consolidated IP address parsing and formatting functions.
+//! Used throughout the codebase for handling IPv4/IPv6 addresses.
+
+const std = @import("std");
+const net = std.net;
+const posix = std.posix;
+
+/// Format a `std.net.Address` (v4 or v6) as a string into the given buffer.
+/// For IPv6 the result uses RFC 3986 notation (`::1` — no brackets, no port).
+/// Returns an empty slice on buffer overflow.
+pub fn formatAddress(addr: net.Address, buf: []u8) []const u8 {
+    switch (addr.any.family) {
+        posix.AF.INET => {
+            return formatIpv4Buf(addr, buf);
+        },
+        posix.AF.INET6 => {
+            // macOS sockaddr_in6 has addr: [16]u8
+            const bytes = &addr.in6.sa.addr;
+            return std.fmt.bufPrint(
+                buf,
+                "{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}",
+                .{
+                    bytes[0],  bytes[1],  bytes[2],  bytes[3],
+                    bytes[4],  bytes[5],  bytes[6],  bytes[7],
+                    bytes[8],  bytes[9],  bytes[10], bytes[11],
+                    bytes[12], bytes[13], bytes[14], bytes[15],
+                },
+            ) catch "";
+        },
+        else => return "",
+    }
+}
+
+/// Format Address as Host header value (bracket-notation for IPv6, plain for IPv4).
+pub fn formatAddressForHost(addr: net.Address, buf: []u8) []const u8 {
+    switch (addr.any.family) {
+        posix.AF.INET => return formatAddress(addr, buf),
+        posix.AF.INET6 => {
+            const raw = formatAddress(addr, buf);
+            if (raw.len == 0) return "";
+            if (buf.len < raw.len + 2) return "";
+            std.mem.copyBackwards(u8, buf[1 .. raw.len + 1], raw);
+            buf[0] = '[';
+            buf[raw.len + 1] = ']';
+            return buf[0 .. raw.len + 2];
+        },
+        else => return "",
+    }
+}
+
+fn formatIpv4Buf(addr: net.Address, buf: []u8) []const u8 {
+    const ip4 = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
+    return std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{
+        ip4[0], ip4[1], ip4[2], ip4[3],
+    }) catch "";
+}
+
+/// Parse IPv4 address string to u32 in host byte order (little-endian on x86/ARM)
+/// Returns null if the string is not a valid IPv4 address.
+///
+/// Example: "192.168.1.1" -> 0x0101A8C0 (little-endian)
+pub fn parseIpv4(str: []const u8) ?u32 {
+    var octets: [4]u8 = [_]u8{ 0, 0, 0, 0 };
+    var octet: u32 = 0;
+    var octet_idx: usize = 0;
+
+    for (str) |c| {
+        if (c == '.') {
+            if (octet > 255 or octet_idx >= 4) return null;
+            octets[octet_idx] = @truncate(octet);
+            octet_idx += 1;
+            octet = 0;
+        } else if (c >= '0' and c <= '9') {
+            octet = octet * 10 + (c - '0');
+        } else {
+            return null;
+        }
+    }
+
+    if (octet > 255 or octet_idx != 3) return null;
+    octets[3] = @truncate(octet);
+
+    // Return in host byte order (little-endian) using bitcast
+    return @as(u32, @bitCast(octets));
+}
+
+/// Format u32 IPv4 address to string
+/// Pack protocol stores IPs in host byte order (little-endian on x86/ARM)
+///
+/// Example: 0x0101A8C0 -> "192.168.1.1"
+pub fn formatIpv4(ip: u32, buffer: []u8) []const u8 {
+    const ip_bytes: [4]u8 = @bitCast(ip);
+    const result = std.fmt.bufPrint(buffer, "{d}.{d}.{d}.{d}", .{
+        ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3],
+    }) catch return "";
+    return result;
+}
+
+/// Convert u32 IP to byte array
+pub fn ipToBytes(ip: u32) [4]u8 {
+    return @bitCast(ip);
+}
+
+/// Convert byte array to u32 IP
+pub fn bytesToIp(bytes: [4]u8) u32 {
+    return @bitCast(bytes);
+}
+
+/// Convert IP from host byte order to network byte order (big-endian)
+pub fn hostToNetwork(ip: u32) u32 {
+    return @byteSwap(ip);
+}
+
+/// Convert IP from network byte order to host byte order
+pub fn networkToHost(ip: u32) u32 {
+    return @byteSwap(ip);
+}
+
+/// Format IP with port as "ip:port"
+pub fn formatIpPort(ip: u32, port: u16, buffer: []u8) []const u8 {
+    const ip_bytes: [4]u8 = @bitCast(ip);
+    const result = std.fmt.bufPrint(buffer, "{d}.{d}.{d}.{d}:{d}", .{
+        ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3], port,
+    }) catch return "";
+    return result;
+}
+
+/// Check if IP is in private range (RFC 1918)
+pub fn isPrivate(ip: u32) bool {
+    const bytes = ipToBytes(ip);
+    // 10.0.0.0/8
+    if (bytes[0] == 10) return true;
+    // 172.16.0.0/12
+    if (bytes[0] == 172 and bytes[1] >= 16 and bytes[1] <= 31) return true;
+    // 192.168.0.0/16
+    if (bytes[0] == 192 and bytes[1] == 168) return true;
+    return false;
+}
+
+/// Check if IP is loopback (127.0.0.0/8)
+pub fn isLoopback(ip: u32) bool {
+    const bytes = ipToBytes(ip);
+    return bytes[0] == 127;
+}
+
+/// Check if IP is link-local (169.254.0.0/16)
+pub fn isLinkLocal(ip: u32) bool {
+    const bytes = ipToBytes(ip);
+    return bytes[0] == 169 and bytes[1] == 254;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "parseIpv4 valid addresses" {
+    // Note: parseIpv4 returns IP in little-endian host byte order
+    // 192.168.1.1 -> bytes [192, 168, 1, 1] -> u32 0x0101A8C0 on little-endian
+    const ip = parseIpv4("192.168.1.1").?;
+    const bytes = ipToBytes(ip);
+    try std.testing.expectEqual(@as(u8, 192), bytes[0]);
+    try std.testing.expectEqual(@as(u8, 168), bytes[1]);
+    try std.testing.expectEqual(@as(u8, 1), bytes[2]);
+    try std.testing.expectEqual(@as(u8, 1), bytes[3]);
+
+    // 127.0.0.1
+    const lo = parseIpv4("127.0.0.1").?;
+    const lo_bytes = ipToBytes(lo);
+    try std.testing.expectEqual(@as(u8, 127), lo_bytes[0]);
+    try std.testing.expectEqual(@as(u8, 0), lo_bytes[1]);
+
+    // 0.0.0.0
+    try std.testing.expectEqual(@as(u32, 0x00000000), parseIpv4("0.0.0.0").?);
+}
+
+test "parseIpv4 invalid addresses" {
+    try std.testing.expect(parseIpv4("invalid") == null);
+    try std.testing.expect(parseIpv4("256.1.1.1") == null);
+    try std.testing.expect(parseIpv4("1.2.3") == null);
+    try std.testing.expect(parseIpv4("1.2.3.4.5") == null);
+    try std.testing.expect(parseIpv4("") == null);
+    try std.testing.expect(parseIpv4("a.b.c.d") == null);
+}
+
+test "formatIpv4" {
+    var buf: [16]u8 = undefined;
+    // Build IP from bytes [192, 168, 1, 1]
+    const ip = bytesToIp(.{ 192, 168, 1, 1 });
+    try std.testing.expectEqualStrings("192.168.1.1", formatIpv4(ip, &buf));
+
+    const lo = bytesToIp(.{ 127, 0, 0, 1 });
+    try std.testing.expectEqualStrings("127.0.0.1", formatIpv4(lo, &buf));
+
+    try std.testing.expectEqualStrings("0.0.0.0", formatIpv4(0x00000000, &buf));
+}
+
+test "ipToBytes and bytesToIp roundtrip" {
+    const bytes: [4]u8 = .{ 192, 168, 1, 1 };
+    const ip = bytesToIp(bytes);
+    try std.testing.expectEqual(bytes, ipToBytes(ip));
+}
+
+test "isPrivate" {
+    try std.testing.expect(isPrivate(bytesToIp(.{ 10, 0, 0, 1 })));
+    try std.testing.expect(isPrivate(bytesToIp(.{ 172, 16, 0, 1 })));
+    try std.testing.expect(isPrivate(bytesToIp(.{ 192, 168, 1, 1 })));
+    try std.testing.expect(!isPrivate(bytesToIp(.{ 8, 8, 8, 8 })));
+}
+
+test "isLoopback" {
+    try std.testing.expect(isLoopback(bytesToIp(.{ 127, 0, 0, 1 })));
+    try std.testing.expect(isLoopback(bytesToIp(.{ 127, 255, 255, 255 })));
+    try std.testing.expect(!isLoopback(bytesToIp(.{ 128, 0, 0, 1 })));
+}
+
+test "isLinkLocal" {
+    try std.testing.expect(isLinkLocal(bytesToIp(.{ 169, 254, 1, 1 })));
+    try std.testing.expect(!isLinkLocal(bytesToIp(.{ 169, 255, 1, 1 })));
+}

--- a/src/mayaqua/kernel/mod.zig
+++ b/src/mayaqua/kernel/mod.zig
@@ -1,0 +1,28 @@
+//! Core Module
+//!
+//! Shared utilities, types, and constants used across the codebase.
+
+pub const ip = @import("ip.zig");
+pub const types = @import("types.zig");
+pub const errors = @import("errors.zig");
+
+// Re-export commonly used functions
+pub const parseIpv4 = ip.parseIpv4;
+pub const formatIpv4 = ip.formatIpv4;
+pub const ipToBytes = ip.ipToBytes;
+pub const bytesToIp = ip.bytesToIp;
+pub const formatAddress = ip.formatAddress;
+pub const formatAddressForHost = ip.formatAddressForHost;
+
+// Re-export common types
+pub const IpAddress = types.IpAddress;
+pub const MacAddress = types.MacAddress;
+pub const ConnectionStatus = types.ConnectionStatus;
+
+// Re-export errors
+pub const VpnError = errors.VpnError;
+pub const errorMessage = errors.errorMessage;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/mayaqua/kernel/types.zig
+++ b/src/mayaqua/kernel/types.zig
@@ -1,0 +1,107 @@
+//! Core Types
+//!
+//! Common types used throughout the codebase.
+
+const std = @import("std");
+
+/// MAC address (6 bytes)
+pub const MacAddress = [6]u8;
+
+/// IP address (IPv4 or IPv6)
+pub const IpAddress = union(enum) {
+    ipv4: [4]u8,
+    ipv6: [16]u8,
+
+    pub fn format(
+        self: IpAddress,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+
+        switch (self) {
+            .ipv4 => |addr| {
+                try writer.print("{d}.{d}.{d}.{d}", .{
+                    addr[0], addr[1], addr[2], addr[3],
+                });
+            },
+            .ipv6 => |addr| {
+                try writer.print("{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}", .{
+                    addr[0],  addr[1],  addr[2],  addr[3],
+                    addr[4],  addr[5],  addr[6],  addr[7],
+                    addr[8],  addr[9],  addr[10], addr[11],
+                    addr[12], addr[13], addr[14], addr[15],
+                });
+            },
+        }
+    }
+
+    /// Create IPv4 address from u32
+    pub fn fromU32(ip: u32) IpAddress {
+        return .{ .ipv4 = @bitCast(ip) };
+    }
+
+    /// Convert to u32 (IPv4 only)
+    pub fn toU32(self: IpAddress) ?u32 {
+        return switch (self) {
+            .ipv4 => |addr| @bitCast(addr),
+            .ipv6 => null,
+        };
+    }
+};
+
+/// VPN connection status
+pub const ConnectionStatus = enum {
+    disconnected,
+    connecting,
+    connected,
+    disconnecting,
+    error_state,
+};
+
+/// Protocol type
+pub const ProtocolType = enum {
+    tcp,
+    udp,
+};
+
+/// VPN session statistics (basic)
+pub const SessionStats = struct {
+    bytes_sent: u64 = 0,
+    bytes_received: u64 = 0,
+    packets_sent: u64 = 0,
+    packets_received: u64 = 0,
+    connected_time_ms: u64 = 0,
+};
+
+/// Network interface info
+pub const InterfaceInfo = struct {
+    name: []const u8,
+    mac: MacAddress,
+    ipv4: ?[4]u8 = null,
+    ipv6: ?[16]u8 = null,
+    mtu: u32 = 1500,
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "IpAddress IPv4 formatting" {
+    const ipv4 = IpAddress{ .ipv4 = .{ 192, 168, 1, 1 } };
+    var buf: [64]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try ipv4.format("", .{}, fbs.writer());
+    try std.testing.expectEqualStrings("192.168.1.1", fbs.getWritten());
+}
+
+test "IpAddress fromU32 and toU32" {
+    const ip = IpAddress.fromU32(0xC0A80101);
+    try std.testing.expectEqual(@as(u32, 0xC0A80101), ip.toU32().?);
+}
+
+test "MacAddress size" {
+    try std.testing.expectEqual(@as(usize, 6), @sizeOf(MacAddress));
+}

--- a/src/mayaqua/main.zig
+++ b/src/mayaqua/main.zig
@@ -1,0 +1,24 @@
+//! Mayaqua — Platform Abstraction Layer
+//!
+//! Mirrors SoftEtherVPN's Mayaqua/ module: OS abstraction, crypto, networking,
+//! and core utilities. NO VPN protocol logic lives here.
+//!
+//! ## Modules
+//! - `encrypt/` — Cryptography (SHA-0, SHA-1, SHA-256, AES-CBC)
+//! - `kernel/`  — Core types, errors, IP utilities
+//! - `network/` — Socket I/O, TLS, HTTP, DNS, SOCKS
+
+pub const encrypt = struct {
+    pub usingnamespace @import("encrypt/crypto.zig");
+    pub const cipher = @import("encrypt/cipher.zig");
+    pub const hash = @import("encrypt/hash.zig");
+    pub const sha0 = @import("encrypt/sha0.zig");
+};
+
+pub const kernel = @import("kernel/mod.zig");
+
+pub const network = @import("network/net.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/mayaqua/network/dns_cache.zig
+++ b/src/mayaqua/network/dns_cache.zig
@@ -1,0 +1,334 @@
+//! DNS Cache with TTL Awareness
+//!
+//! Provides a thread-safe DNS resolution cache that stores resolved addresses
+//! with configurable TTL to avoid repeated OS-level DNS lookups during
+//! reconnection cycles.
+
+const std = @import("std");
+const net = std.net;
+const Allocator = std.mem.Allocator;
+const Mutex = std.Thread.Mutex;
+const testing = std.testing;
+
+const log = std.log.scoped(.dns_cache);
+
+/// Default TTL for cached entries (seconds)
+const DEFAULT_TTL_SECS: i64 = 300; // 5 minutes
+
+/// Maximum number of cached hostnames
+const MAX_CACHE_ENTRIES: usize = 64;
+
+/// A cached DNS resolution result
+pub const CacheEntry = struct {
+    addresses: []net.Address,
+    /// Timestamp (seconds since epoch) when this entry expires
+    expires_at: i64,
+    /// How many times this entry has been used
+    hit_count: u64 = 0,
+
+    fn isExpired(self: *const CacheEntry, now: i64) bool {
+        return now >= self.expires_at;
+    }
+};
+
+/// Thread-safe DNS cache with TTL-based expiration
+pub const DnsCache = struct {
+    entries: std.StringHashMap(CacheEntry),
+    allocator: Allocator,
+    mutex: Mutex = .{},
+    ttl_secs: i64,
+    stats: Stats = .{},
+
+    pub const Stats = struct {
+        hits: u64 = 0,
+        misses: u64 = 0,
+        evictions: u64 = 0,
+    };
+
+    pub fn init(allocator: Allocator, ttl_secs: ?i64) DnsCache {
+        return .{
+            .entries = std.StringHashMap(CacheEntry).init(allocator),
+            .allocator = allocator,
+            .ttl_secs = ttl_secs orelse DEFAULT_TTL_SECS,
+        };
+    }
+
+    pub fn deinit(self: *DnsCache) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.value_ptr.addresses);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.entries.deinit();
+    }
+
+    /// Look up a hostname in the cache. Returns cached addresses if valid.
+    pub fn get(self: *DnsCache, hostname: []const u8) ?[]const net.Address {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const now = std.time.timestamp();
+
+        if (self.entries.getPtr(hostname)) |entry| {
+            if (entry.isExpired(now)) {
+                log.debug("Cache expired for {s}", .{hostname});
+                self.removeEntryLocked(hostname);
+                self.stats.misses += 1;
+                return null;
+            }
+            entry.hit_count += 1;
+            self.stats.hits += 1;
+            log.debug("Cache hit for {s} ({d} addrs, hit #{d})", .{
+                hostname, entry.addresses.len, entry.hit_count,
+            });
+            return entry.addresses;
+        }
+
+        self.stats.misses += 1;
+        return null;
+    }
+
+    /// Store resolved addresses for a hostname with TTL.
+    pub fn put(self: *DnsCache, hostname: []const u8, addresses: []const net.Address) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const now = std.time.timestamp();
+
+        // Evict expired entries if at capacity
+        if (self.entries.count() >= MAX_CACHE_ENTRIES) {
+            self.evictExpiredLocked(now);
+        }
+
+        // If still at capacity, evict the oldest entry
+        if (self.entries.count() >= MAX_CACHE_ENTRIES) {
+            self.evictOldestLocked();
+        }
+
+        // Remove existing entry for this hostname
+        if (self.entries.contains(hostname)) {
+            self.removeEntryLocked(hostname);
+        }
+
+        // Copy the hostname and addresses into owned memory
+        const owned_hostname = try self.allocator.dupe(u8, hostname);
+        errdefer self.allocator.free(owned_hostname);
+
+        const owned_addrs = try self.allocator.dupe(net.Address, addresses);
+        errdefer self.allocator.free(owned_addrs);
+
+        try self.entries.put(owned_hostname, .{
+            .addresses = owned_addrs,
+            .expires_at = now + self.ttl_secs,
+        });
+
+        log.debug("Cached {d} addrs for {s} (TTL {d}s)", .{
+            addresses.len, hostname, self.ttl_secs,
+        });
+    }
+
+    /// Invalidate a specific hostname entry.
+    pub fn invalidate(self: *DnsCache, hostname: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.removeEntryLocked(hostname);
+    }
+
+    /// Clear all cached entries.
+    pub fn clear(self: *DnsCache) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.value_ptr.addresses);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.entries.clearAndFree();
+    }
+
+    /// Resolve a hostname, using the cache if available.
+    /// Falls back to OS-level DNS resolution on cache miss.
+    pub fn resolveWithCache(self: *DnsCache, hostname: []const u8, port: u16) ![]const net.Address {
+        // Check cache first
+        if (self.get(hostname)) |cached| {
+            return cached;
+        }
+
+        // Cache miss — do real DNS resolution
+        const addr_list = try net.getAddressList(self.allocator, hostname, port);
+        defer addr_list.deinit();
+
+        if (addr_list.addrs.len == 0) {
+            return error.UnknownHostName;
+        }
+
+        // Store in cache
+        try self.put(hostname, addr_list.addrs);
+
+        // Return the cached copy (which we just inserted)
+        return self.get(hostname) orelse error.UnknownHostName;
+    }
+
+    // -- Internal helpers (caller must hold mutex) --
+
+    fn removeEntryLocked(self: *DnsCache, hostname: []const u8) void {
+        if (self.entries.fetchRemove(hostname)) |kv| {
+            self.allocator.free(kv.value.addresses);
+            self.allocator.free(kv.key);
+        }
+    }
+
+    fn evictExpiredLocked(self: *DnsCache, now: i64) void {
+        var to_remove = std.ArrayListUnmanaged([]const u8){};
+        defer to_remove.deinit(self.allocator);
+
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.isExpired(now)) {
+                to_remove.append(self.allocator, entry.key_ptr.*) catch continue;
+            }
+        }
+
+        for (to_remove.items) |key| {
+            if (self.entries.fetchRemove(key)) |kv| {
+                self.allocator.free(kv.value.addresses);
+                self.allocator.free(kv.key);
+                self.stats.evictions += 1;
+            }
+        }
+    }
+
+    fn evictOldestLocked(self: *DnsCache) void {
+        var oldest_key: ?[]const u8 = null;
+        var oldest_expires: i64 = std.math.maxInt(i64);
+
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.expires_at < oldest_expires) {
+                oldest_expires = entry.value_ptr.expires_at;
+                oldest_key = entry.key_ptr.*;
+            }
+        }
+
+        if (oldest_key) |key| {
+            if (self.entries.fetchRemove(key)) |kv| {
+                self.allocator.free(kv.value.addresses);
+                self.allocator.free(kv.key);
+                self.stats.evictions += 1;
+            }
+        }
+    }
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "DnsCache init and deinit" {
+    var cache = DnsCache.init(testing.allocator, 60);
+    defer cache.deinit();
+
+    try testing.expectEqual(@as(i64, 60), cache.ttl_secs);
+    try testing.expectEqual(@as(u64, 0), cache.stats.hits);
+    try testing.expectEqual(@as(u64, 0), cache.stats.misses);
+}
+
+test "DnsCache get returns null for missing" {
+    var cache = DnsCache.init(testing.allocator, 60);
+    defer cache.deinit();
+
+    const result = cache.get("nonexistent.example.com");
+    try testing.expect(result == null);
+    try testing.expectEqual(@as(u64, 1), cache.stats.misses);
+}
+
+test "DnsCache put and get round-trip" {
+    var cache = DnsCache.init(testing.allocator, 300);
+    defer cache.deinit();
+
+    const addr = try net.Address.parseIp4("1.2.3.4", 443);
+    const addrs = [_]net.Address{addr};
+    try cache.put("example.com", &addrs);
+
+    const cached = cache.get("example.com");
+    try testing.expect(cached != null);
+    try testing.expectEqual(@as(usize, 1), cached.?.len);
+    try testing.expectEqual(@as(u16, 443), cached.?[0].getPort());
+    try testing.expectEqual(@as(u64, 1), cache.stats.hits);
+}
+
+test "DnsCache invalidate removes entry" {
+    var cache = DnsCache.init(testing.allocator, 300);
+    defer cache.deinit();
+
+    const addr = try net.Address.parseIp4("10.0.0.1", 80);
+    const addrs = [_]net.Address{addr};
+    try cache.put("test.local", &addrs);
+
+    try testing.expect(cache.get("test.local") != null);
+    cache.invalidate("test.local");
+    try testing.expect(cache.get("test.local") == null);
+}
+
+test "DnsCache clear removes all entries" {
+    var cache = DnsCache.init(testing.allocator, 300);
+    defer cache.deinit();
+
+    const addr1 = try net.Address.parseIp4("1.1.1.1", 53);
+    const addr2 = try net.Address.parseIp4("8.8.8.8", 53);
+    try cache.put("dns1.example.com", &[_]net.Address{addr1});
+    try cache.put("dns2.example.com", &[_]net.Address{addr2});
+
+    cache.clear();
+    try testing.expect(cache.get("dns1.example.com") == null);
+    try testing.expect(cache.get("dns2.example.com") == null);
+}
+
+test "DnsCache multiple addresses per hostname" {
+    var cache = DnsCache.init(testing.allocator, 300);
+    defer cache.deinit();
+
+    const addr1 = try net.Address.parseIp4("10.0.0.1", 443);
+    const addr2 = try net.Address.parseIp4("10.0.0.2", 443);
+    const addrs = [_]net.Address{ addr1, addr2 };
+    try cache.put("multi.example.com", &addrs);
+
+    const cached = cache.get("multi.example.com");
+    try testing.expect(cached != null);
+    try testing.expectEqual(@as(usize, 2), cached.?.len);
+}
+
+test "DnsCache replaces existing entry" {
+    var cache = DnsCache.init(testing.allocator, 300);
+    defer cache.deinit();
+
+    const addr1 = try net.Address.parseIp4("1.1.1.1", 443);
+    try cache.put("replace.example.com", &[_]net.Address{addr1});
+
+    const addr2 = try net.Address.parseIp4("2.2.2.2", 443);
+    try cache.put("replace.example.com", &[_]net.Address{addr2});
+
+    const cached = cache.get("replace.example.com");
+    try testing.expect(cached != null);
+    try testing.expectEqual(@as(usize, 1), cached.?.len);
+}
+
+test "DnsCache stats tracking" {
+    var cache = DnsCache.init(testing.allocator, 300);
+    defer cache.deinit();
+
+    _ = cache.get("miss1.com");
+    _ = cache.get("miss2.com");
+
+    const addr = try net.Address.parseIp4("1.2.3.4", 80);
+    try cache.put("hit.com", &[_]net.Address{addr});
+    _ = cache.get("hit.com");
+    _ = cache.get("hit.com");
+
+    try testing.expectEqual(@as(u64, 2), cache.stats.hits);
+    try testing.expectEqual(@as(u64, 2), cache.stats.misses);
+}

--- a/src/mayaqua/network/http.zig
+++ b/src/mayaqua/network/http.zig
@@ -1,0 +1,459 @@
+//! HTTP Module
+//!
+//! HTTP client utilities for SoftEther VPN connections.
+//! Handles HTTP CONNECT proxy and initial HTTP handshake.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const testing = std.testing;
+const net = std.net;
+
+const socket = @import("socket.zig");
+const TcpSocket = socket.TcpSocket;
+const socks = @import("socks.zig");
+
+/// HTTP method
+pub const Method = enum {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    HEAD,
+    OPTIONS,
+    CONNECT,
+    PATCH,
+
+    pub fn toString(self: Method) []const u8 {
+        return switch (self) {
+            .GET => "GET",
+            .POST => "POST",
+            .PUT => "PUT",
+            .DELETE => "DELETE",
+            .HEAD => "HEAD",
+            .OPTIONS => "OPTIONS",
+            .CONNECT => "CONNECT",
+            .PATCH => "PATCH",
+        };
+    }
+};
+
+/// HTTP status code
+pub const StatusCode = enum(u16) {
+    ok = 200,
+    created = 201,
+    accepted = 202,
+    no_content = 204,
+    moved_permanently = 301,
+    found = 302,
+    see_other = 303,
+    not_modified = 304,
+    bad_request = 400,
+    unauthorized = 401,
+    forbidden = 403,
+    not_found = 404,
+    method_not_allowed = 405,
+    proxy_auth_required = 407,
+    request_timeout = 408,
+    internal_server_error = 500,
+    bad_gateway = 502,
+    service_unavailable = 503,
+    gateway_timeout = 504,
+    _,
+
+    pub fn isSuccess(self: StatusCode) bool {
+        const code = @intFromEnum(self);
+        return code >= 200 and code < 300;
+    }
+
+    pub fn isRedirect(self: StatusCode) bool {
+        const code = @intFromEnum(self);
+        return code >= 300 and code < 400;
+    }
+
+    pub fn isClientError(self: StatusCode) bool {
+        const code = @intFromEnum(self);
+        return code >= 400 and code < 500;
+    }
+
+    pub fn isServerError(self: StatusCode) bool {
+        const code = @intFromEnum(self);
+        return code >= 500;
+    }
+};
+
+/// HTTP version
+pub const Version = enum {
+    http_1_0,
+    http_1_1,
+
+    pub fn toString(self: Version) []const u8 {
+        return switch (self) {
+            .http_1_0 => "HTTP/1.0",
+            .http_1_1 => "HTTP/1.1",
+        };
+    }
+};
+
+/// HTTP header
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// HTTP request builder
+pub const Request = struct {
+    method: Method,
+    path: []const u8,
+    version: Version = .http_1_1,
+    headers: std.ArrayListUnmanaged(Header),
+    body: ?[]const u8 = null,
+    allocator: Allocator,
+
+    pub fn init(allocator: Allocator, method: Method, path: []const u8) Request {
+        return .{
+            .method = method,
+            .path = path,
+            .headers = .{},
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Request) void {
+        self.headers.deinit(self.allocator);
+    }
+
+    pub fn addHeader(self: *Request, name: []const u8, value: []const u8) !void {
+        try self.headers.append(self.allocator, .{ .name = name, .value = value });
+    }
+
+    pub fn setBody(self: *Request, body: []const u8) void {
+        self.body = body;
+    }
+
+    /// Format request to buffer
+    pub fn format(self: *const Request, buf: []u8) ![]u8 {
+        var stream = std.io.fixedBufferStream(buf);
+        const writer = stream.writer();
+
+        // Request line
+        try writer.print("{s} {s} {s}\r\n", .{
+            self.method.toString(),
+            self.path,
+            self.version.toString(),
+        });
+
+        // Headers
+        for (self.headers.items) |header| {
+            try writer.print("{s}: {s}\r\n", .{ header.name, header.value });
+        }
+
+        // Content-Length if body present
+        if (self.body) |body| {
+            try writer.print("Content-Length: {d}\r\n", .{body.len});
+        }
+
+        // End of headers
+        try writer.writeAll("\r\n");
+
+        // Body
+        if (self.body) |body| {
+            try writer.writeAll(body);
+        }
+
+        return buf[0..stream.pos];
+    }
+};
+
+/// HTTP response parser
+pub const Response = struct {
+    version: Version,
+    status_code: StatusCode,
+    status_text: []const u8,
+    headers: std.StringHashMap([]const u8),
+    body: []const u8,
+    raw_data: []u8,
+    allocator: Allocator,
+
+    pub fn deinit(self: *Response) void {
+        self.headers.deinit();
+        self.allocator.free(self.raw_data);
+    }
+
+    /// Get header value (case-insensitive)
+    pub fn getHeader(self: *const Response, name: []const u8) ?[]const u8 {
+        // Headers are stored lowercased
+        var lower_name: [256]u8 = undefined;
+        const lower = toLowerBuf(name, &lower_name) catch return null;
+        return self.headers.get(lower);
+    }
+
+    pub fn getContentLength(self: *const Response) ?usize {
+        const value = self.getHeader("content-length") orelse return null;
+        return std.fmt.parseInt(usize, value, 10) catch null;
+    }
+
+    pub fn isChunked(self: *const Response) bool {
+        const encoding = self.getHeader("transfer-encoding") orelse return false;
+        return std.mem.indexOf(u8, encoding, "chunked") != null;
+    }
+};
+
+/// Parse HTTP response from socket
+pub fn parseResponse(allocator: Allocator, reader: anytype) !Response {
+    var raw = std.ArrayListUnmanaged(u8){};
+    errdefer raw.deinit(allocator);
+
+    // Read until we find \r\n\r\n (end of headers)
+    var found_end = false;
+    var buf: [4096]u8 = undefined;
+    var header_end: usize = 0;
+
+    while (!found_end) {
+        const n = try reader.read(&buf);
+        if (n == 0) return error.ConnectionClosed;
+
+        const start_search = if (raw.items.len >= 3) raw.items.len - 3 else 0;
+        try raw.appendSlice(allocator, buf[0..n]);
+
+        // Look for \r\n\r\n
+        for (start_search..raw.items.len -| 3) |i| {
+            if (std.mem.eql(u8, raw.items[i .. i + 4], "\r\n\r\n")) {
+                found_end = true;
+                header_end = i + 4;
+                break;
+            }
+        }
+
+        if (raw.items.len > 64 * 1024) {
+            return error.ResponseTooLarge;
+        }
+    }
+
+    const raw_data = try raw.toOwnedSlice(allocator);
+    errdefer allocator.free(raw_data);
+
+    // Parse status line
+    const status_line_end = std.mem.indexOf(u8, raw_data, "\r\n") orelse return error.InvalidResponse;
+    const status_line = raw_data[0..status_line_end];
+
+    // Parse "HTTP/1.1 200 OK"
+    var parts = std.mem.tokenizeScalar(u8, status_line, ' ');
+    const version_str = parts.next() orelse return error.InvalidResponse;
+    const status_str = parts.next() orelse return error.InvalidResponse;
+    const status_text = parts.rest();
+
+    const version: Version = if (std.mem.eql(u8, version_str, "HTTP/1.0"))
+        .http_1_0
+    else if (std.mem.eql(u8, version_str, "HTTP/1.1"))
+        .http_1_1
+    else
+        return error.UnsupportedHttpVersion;
+
+    const status_code: StatusCode = @enumFromInt(std.fmt.parseInt(u16, status_str, 10) catch return error.InvalidStatusCode);
+
+    // Parse headers
+    var headers = std.StringHashMap([]const u8).init(allocator);
+    errdefer headers.deinit();
+
+    const headers_data = raw_data[status_line_end + 2 .. header_end - 2];
+    var lines = std.mem.splitSequence(u8, headers_data, "\r\n");
+
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+
+        const colon = std.mem.indexOf(u8, line, ":") orelse continue;
+        const name = std.mem.trim(u8, line[0..colon], " ");
+        const value = std.mem.trim(u8, line[colon + 1 ..], " ");
+
+        // Store lowercase header name
+        var lower_name: [256]u8 = undefined;
+        const lower = try toLowerBuf(name, &lower_name);
+
+        // Store reference to data in raw_data
+        try headers.put(lower, value);
+    }
+
+    return .{
+        .version = version,
+        .status_code = status_code,
+        .status_text = status_text,
+        .headers = headers,
+        .body = raw_data[header_end..],
+        .raw_data = raw_data,
+        .allocator = allocator,
+    };
+}
+
+fn toLowerBuf(str: []const u8, buf: []u8) ![]u8 {
+    if (str.len > buf.len) return error.BufferTooSmall;
+    for (str, 0..) |c, i| {
+        buf[i] = std.ascii.toLower(c);
+    }
+    return buf[0..str.len];
+}
+
+// ============================================================================
+// HTTP CONNECT proxy support (for SoftEther through proxy)
+// ============================================================================
+
+/// HTTP proxy configuration
+pub const ProxyConfig = struct {
+    host: []const u8,
+    port: u16,
+    username: ?[]const u8 = null,
+    password: ?[]const u8 = null,
+    proxy_type: ProxyType = .http,
+
+    pub const ProxyType = enum {
+        http,
+        socks4,
+        socks5,
+    };
+};
+
+/// Connect through proxy (HTTP CONNECT, SOCKS4, or SOCKS5).
+/// Returns a TcpSocket connected to the target host through the proxy.
+pub fn connectViaProxy(
+    allocator: Allocator,
+    proxy: ProxyConfig,
+    target_host: []const u8,
+    target_port: u16,
+) !TcpSocket {
+    return switch (proxy.proxy_type) {
+        .http => connectViaHttpConnect(allocator, proxy, target_host, target_port),
+        .socks4 => socks.connectViaSocks4(allocator, .{
+            .host = proxy.host,
+            .port = proxy.port,
+            .username = proxy.username,
+            .password = proxy.password,
+        }, target_host, target_port),
+        .socks5 => socks.connectViaSocks5(allocator, .{
+            .host = proxy.host,
+            .port = proxy.port,
+            .username = proxy.username,
+            .password = proxy.password,
+        }, target_host, target_port),
+    };
+}
+
+/// Connect through HTTP CONNECT proxy
+fn connectViaHttpConnect(
+    allocator: Allocator,
+    proxy: ProxyConfig,
+    target_host: []const u8,
+    target_port: u16,
+) !TcpSocket {
+    // Connect to proxy
+    var tcp = try TcpSocket.connectHost(proxy.host, proxy.port, 30000);
+    errdefer tcp.close();
+
+    // Build CONNECT request
+    var req = Request.init(allocator, .CONNECT, target_host);
+    defer req.deinit();
+
+    // Host header with port
+    var host_buf: [256]u8 = undefined;
+    const host = try std.fmt.bufPrint(&host_buf, "{s}:{d}", .{ target_host, target_port });
+    try req.addHeader("Host", host);
+
+    // Proxy auth if needed
+    if (proxy.username) |username| {
+        if (proxy.password) |password| {
+            // Base64 encode username:password
+            var auth_buf: [512]u8 = undefined;
+            const auth_str = try std.fmt.bufPrint(&auth_buf, "{s}:{s}", .{ username, password });
+
+            var encoded_buf: [1024]u8 = undefined;
+            const encoded_len = std.base64.standard.Encoder.calcSize(auth_str.len);
+            const encoded = encoded_buf[0..encoded_len];
+            _ = std.base64.standard.Encoder.encode(encoded, auth_str);
+
+            var auth_header: [1100]u8 = undefined;
+            const auth_value = try std.fmt.bufPrint(&auth_header, "Basic {s}", .{encoded});
+            try req.addHeader("Proxy-Authorization", auth_value);
+        }
+    }
+
+    // Send request
+    var send_buf: [2048]u8 = undefined;
+    const request_data = try req.format(&send_buf);
+    try tcp.writeAll(request_data);
+
+    // Read response
+    var response = try parseResponse(allocator, tcp.stream);
+    defer response.deinit();
+
+    if (!response.status_code.isSuccess()) {
+        if (response.status_code == .proxy_auth_required) {
+            return error.ProxyAuthRequired;
+        }
+        return error.ProxyConnectionFailed;
+    }
+
+    return tcp;
+}
+
+// ============================================================================
+// SoftEther HTTP layer handshake
+// ============================================================================
+
+/// SoftEther initial HTTP-like handshake format
+pub const SoftEtherHttpHandshake = struct {
+    /// Send SoftEther HTTP-style client hello
+    pub fn sendClientHello(
+        writer: anytype,
+        hub_name: []const u8,
+        client_str: []const u8,
+    ) !void {
+        // SoftEther uses a POST request with specific headers
+        try writer.print("POST /vpnsvc/connect.cgi HTTP/1.1\r\n", .{});
+        try writer.print("Host: vpn\r\n", .{});
+        try writer.print("Content-Type: application/octet-stream\r\n", .{});
+        try writer.print("X-VPN-Hub: {s}\r\n", .{hub_name});
+        try writer.print("User-Agent: {s}\r\n", .{client_str});
+        try writer.print("Connection: Keep-Alive\r\n", .{});
+        try writer.print("Content-Length: 0\r\n", .{});
+        try writer.print("\r\n", .{});
+    }
+
+    /// Parse SoftEther HTTP-style server response
+    pub fn parseServerResponse(reader: anytype) !bool {
+        var buf: [1024]u8 = undefined;
+        const line = (try reader.readUntilDelimiterOrEof(&buf, '\n')) orelse return false;
+
+        // Expect "HTTP/1.1 200 OK" or similar
+        return std.mem.startsWith(u8, line, "HTTP/1.1 200") or
+            std.mem.startsWith(u8, line, "HTTP/1.0 200");
+    }
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "StatusCode classifications" {
+    try testing.expect(StatusCode.ok.isSuccess());
+    try testing.expect(StatusCode.found.isRedirect());
+    try testing.expect(StatusCode.not_found.isClientError());
+    try testing.expect(StatusCode.internal_server_error.isServerError());
+}
+
+test "Request formatting" {
+    var req = Request.init(testing.allocator, .GET, "/api/test");
+    defer req.deinit();
+
+    try req.addHeader("Host", "example.com");
+    try req.addHeader("Accept", "*/*");
+
+    var buf: [1024]u8 = undefined;
+    const formatted = try req.format(&buf);
+
+    try testing.expect(std.mem.startsWith(u8, formatted, "GET /api/test HTTP/1.1\r\n"));
+    try testing.expect(std.mem.indexOf(u8, formatted, "Host: example.com\r\n") != null);
+}
+
+test "Method toString" {
+    try testing.expectEqualStrings("GET", Method.GET.toString());
+    try testing.expectEqualStrings("POST", Method.POST.toString());
+    try testing.expectEqualStrings("CONNECT", Method.CONNECT.toString());
+}

--- a/src/mayaqua/network/net.zig
+++ b/src/mayaqua/network/net.zig
@@ -1,0 +1,35 @@
+//! SoftEther VPN Networking Library
+//!
+//! This module provides Zig networking utilities.
+//! Phase 2 of the C-to-Zig migration.
+
+pub const socket = @import("socket.zig");
+pub const tls = @import("tls.zig");
+pub const http = @import("http.zig");
+pub const dns_cache = @import("dns_cache.zig");
+pub const socks = @import("socks.zig");
+pub const dhcpv6 = @import("../../tunnel/dhcpv6.zig");
+
+// Re-export commonly used types
+pub const TcpSocket = socket.TcpSocket;
+pub const TcpListener = socket.TcpListener;
+pub const Address = socket.Address;
+pub const ConnectionState = socket.ConnectionState;
+pub const ConnectionInfo = socket.ConnectionInfo;
+
+pub const TlsSocket = tls.TlsSocket;
+pub const TlsConfig = tls.TlsConfig;
+pub const TlsVersion = tls.TlsVersion;
+
+pub const HttpRequest = http.Request;
+pub const HttpResponse = http.Response;
+pub const HttpMethod = http.Method;
+pub const StatusCode = http.StatusCode;
+pub const ProxyConfig = http.ProxyConfig;
+
+pub const DnsCache = dns_cache.DnsCache;
+
+// Tests
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/mayaqua/network/socket.zig
+++ b/src/mayaqua/network/socket.zig
@@ -1,0 +1,371 @@
+//! Socket Utilities Module
+//!
+//! Socket operations
+//! Provides cross-platform TCP/UDP socket abstractions.
+
+const std = @import("std");
+const net = std.net;
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
+const testing = std.testing;
+
+const builtin = @import("builtin");
+
+/// Socket error types
+pub const SocketError = error{
+    ConnectionRefused,
+    ConnectionReset,
+    ConnectionTimedOut,
+    HostUnreachable,
+    NetworkUnreachable,
+    AddressInUse,
+    AddressNotAvailable,
+    BrokenPipe,
+    WouldBlock,
+    InvalidAddress,
+    SocketNotConnected,
+    NotSocket,
+    Unexpected,
+};
+
+/// Address family
+pub const AddressFamily = enum {
+    ipv4,
+    ipv6,
+    unspec,
+};
+
+/// Socket address wrapper
+pub const Address = struct {
+    inner: net.Address,
+
+    pub fn parseIp(ip: []const u8, port: u16) !Address {
+        return .{ .inner = try net.Address.parseIp(ip, port) };
+    }
+
+    pub fn parseIp4(ip: []const u8, port: u16) !Address {
+        return .{ .inner = try net.Address.parseIp4(ip, port) };
+    }
+
+    pub fn parseIp6(ip: []const u8, port: u16) !Address {
+        return .{ .inner = try net.Address.parseIp6(ip, port) };
+    }
+
+    pub fn resolveIp(hostname: []const u8, port: u16) !Address {
+        return .{ .inner = try net.Address.resolveIp(hostname, port) };
+    }
+
+    pub fn getPort(self: *const Address) u16 {
+        return self.inner.getPort();
+    }
+
+    pub fn format(self: Address, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+        _ = fmt;
+        _ = options;
+        try self.inner.format("{}", .{}, writer);
+    }
+};
+
+/// TCP Socket wrapper with timeout support
+pub const TcpSocket = struct {
+    stream: net.Stream,
+
+    /// Connect to a remote address with timeout
+    pub fn connect(address: Address, timeout_ms: ?u32) !TcpSocket {
+        const stream = try net.tcpConnectToAddress(address.inner);
+
+        if (timeout_ms) |timeout| {
+            try setReadTimeout(stream.handle, timeout);
+            try setWriteTimeout(stream.handle, timeout);
+        }
+
+        return .{ .stream = stream };
+    }
+
+    /// Connect by hostname with DNS resolution
+    pub fn connectHost(hostname: []const u8, port: u16, timeout_ms: ?u32) !TcpSocket {
+        const address = try Address.resolveIp(hostname, port);
+        return connect(address, timeout_ms);
+    }
+
+    /// Close the socket
+    pub fn close(self: *TcpSocket) void {
+        self.stream.close();
+    }
+
+    /// Read data from socket
+    pub fn read(self: *TcpSocket, buffer: []u8) !usize {
+        return self.stream.read(buffer);
+    }
+
+    /// Read exactly n bytes
+    pub fn readAll(self: *TcpSocket, buffer: []u8) !void {
+        var index: usize = 0;
+        while (index < buffer.len) {
+            const n = try self.stream.read(buffer[index..]);
+            if (n == 0) return error.EndOfStream;
+            index += n;
+        }
+    }
+
+    /// Write data to socket
+    pub fn write(self: *TcpSocket, data: []const u8) !usize {
+        return self.stream.write(data);
+    }
+
+    /// Write all data
+    pub fn writeAll(self: *TcpSocket, data: []const u8) !void {
+        try self.stream.writeAll(data);
+    }
+
+    /// Get socket for use with TLS and socket operations
+    pub fn getFd(self: *const TcpSocket) posix.socket_t {
+        return if (builtin.os.tag == .windows) @ptrCast(self.stream.handle) else self.stream.handle;
+    }
+
+    /// Get socket_t handle for socket operations
+    fn sock(self: *const TcpSocket) posix.socket_t {
+        return if (builtin.os.tag == .windows) @ptrCast(self.stream.handle) else self.stream.handle;
+    }
+
+    /// Set read timeout in milliseconds
+    pub fn setReadTimeout(fd: posix.socket_t, ms: u32) !void {
+        if (builtin.os.tag == .windows) {
+            // Windows: SO_RCVTIMEO takes a DWORD in milliseconds
+            try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&ms));
+        } else {
+            const timeout = posix.timeval{
+                .sec = @intCast(ms / 1000),
+                .usec = @intCast((ms % 1000) * 1000),
+            };
+            try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&timeout));
+        }
+    }
+
+    /// Set write timeout in milliseconds
+    pub fn setWriteTimeout(fd: posix.socket_t, ms: u32) !void {
+        if (builtin.os.tag == .windows) {
+            // Windows: SO_SNDTIMEO takes a DWORD in milliseconds
+            try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&ms));
+        } else {
+            const timeout = posix.timeval{
+                .sec = @intCast(ms / 1000),
+                .usec = @intCast((ms % 1000) * 1000),
+            };
+            try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&timeout));
+        }
+    }
+
+    /// Enable TCP keepalive
+    pub fn setKeepalive(self: *TcpSocket, enable: bool) !void {
+        const val: u32 = if (enable) 1 else 0;
+        try posix.setsockopt(self.sock(), posix.SOL.SOCKET, posix.SO.KEEPALIVE, std.mem.asBytes(&val));
+    }
+
+    /// Set TCP nodelay (disable Nagle's algorithm)
+    pub fn setNoDelay(self: *TcpSocket, enable: bool) !void {
+        const val: u32 = if (enable) 1 else 0;
+        try posix.setsockopt(self.sock(), posix.IPPROTO.TCP, std.posix.TCP.NODELAY, std.mem.asBytes(&val));
+    }
+
+    /// Check if socket has data available (non-blocking)
+    pub fn poll(self: *TcpSocket, timeout_ms: i32) !bool {
+        var pfd = [_]posix.pollfd{
+            .{
+                .fd = self.sock(),
+                .events = posix.POLL.IN,
+                .revents = 0,
+            },
+        };
+
+        const result = try posix.poll(&pfd, timeout_ms);
+        return result > 0 and (pfd[0].revents & posix.POLL.IN) != 0;
+    }
+};
+
+/// TCP Server (listener)
+pub const TcpListener = struct {
+    listener: net.Server,
+
+    pub fn init(address: Address, backlog: u31) !TcpListener {
+        const listener = try address.inner.listen(.{
+            .reuse_address = true,
+            .kernel_backlog = backlog,
+        });
+        return .{ .listener = listener };
+    }
+
+    pub fn initPort(port: u16, backlog: u31) !TcpListener {
+        const address = Address{ .inner = net.Address.initIp4(.{ 0, 0, 0, 0 }, port) };
+        return init(address, backlog);
+    }
+
+    pub fn accept(self: *TcpListener) !TcpSocket {
+        const conn = try self.listener.accept();
+        return .{ .stream = conn };
+    }
+
+    pub fn close(self: *TcpListener) void {
+        self.listener.deinit();
+    }
+
+    pub fn getLocalAddress(self: *const TcpListener) Address {
+        return .{ .inner = self.listener.listen_address };
+    }
+};
+
+// ============================================================================
+// UDP Socket
+// ============================================================================
+
+/// UDP Socket wrapper for datagram I/O
+pub const UdpSocket = struct {
+    fd: posix.socket_t,
+    bound_port: u16 = 0,
+
+    /// Create and bind a UDP socket to a local port (0 = system-assigned).
+    pub fn bind(port: u16, family: AddressFamily) !UdpSocket {
+        _ = family; // Use IPv4 for now; address family determined by bind address
+
+        // Create IPv4 UDP socket using net.Address to get correct AF
+        const bind_addr = net.Address.initIp4(.{ 0, 0, 0, 0 }, port);
+        const fd = try posix.socket(bind_addr.any.family, posix.SOCK.DGRAM | posix.SOCK.NONBLOCK, 0);
+        errdefer posix.close(fd);
+
+        // Allow address reuse
+        const one: u32 = 1;
+        try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&one));
+
+        // Bind
+        try posix.bind(fd, &bind_addr.any, bind_addr.getOsSockLen());
+
+        // Retrieve actual bound port
+        var actual = bind_addr;
+        var actual_len = bind_addr.getOsSockLen();
+        try posix.getsockname(fd, &actual.any, &actual_len);
+        const real_port = actual.getPort();
+
+        return .{ .fd = fd, .bound_port = real_port };
+    }
+
+    /// Close the socket.
+    pub fn close(self: *UdpSocket) void {
+        if (builtin.os.tag == .windows) {
+            _ = std.os.windows.ws2_32.closesocket(self.fd);
+            self.fd = @ptrFromInt(std.math.maxInt(usize));
+        } else {
+            posix.close(self.fd);
+            self.fd = -1;
+        }
+    }
+
+    /// Send a datagram to a specific address.
+    pub fn sendTo(self: *const UdpSocket, data: []const u8, dest: Address) !usize {
+        const sa = dest.inner.any;
+        const sa_len = dest.inner.getOsSockLen();
+        const rc = posix.sendto(self.fd, data, 0, &sa, sa_len) catch |err| switch (err) {
+            error.WouldBlock => return 0,
+            else => return err,
+        };
+        return rc;
+    }
+
+    /// Receive a datagram. Returns bytes read and sender address.
+    pub fn recvFrom(self: *const UdpSocket, buf: []u8) !struct { len: usize, from: Address } {
+        var src_addr: posix.sockaddr.storage = undefined;
+        var src_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+        const n = posix.recvfrom(self.fd, buf, 0, @ptrCast(&src_addr), &src_len) catch |err| switch (err) {
+            error.WouldBlock => return .{ .len = 0, .from = undefined },
+            else => return err,
+        };
+        const addr = net.Address.initPosix(@ptrCast(&src_addr));
+        return .{ .len = n, .from = .{ .inner = addr } };
+    }
+
+    /// Get the socket for use with poll().
+    pub fn getFd(self: *const UdpSocket) posix.socket_t {
+        return self.fd;
+    }
+
+    /// Set receive buffer size.
+    pub fn setRecvBufSize(self: *const UdpSocket, size: u32) !void {
+        try posix.setsockopt(self.fd, posix.SOL.SOCKET, posix.SO.RCVBUF, std.mem.asBytes(&size));
+    }
+
+    /// Set send buffer size.
+    pub fn setSendBufSize(self: *const UdpSocket, size: u32) !void {
+        try posix.setsockopt(self.fd, posix.SOL.SOCKET, posix.SO.SNDBUF, std.mem.asBytes(&size));
+    }
+};
+
+// ============================================================================
+// DNS resolution utilities
+// ============================================================================
+
+/// DNS resolver result
+pub const ResolvedAddress = struct {
+    addresses: []net.Address,
+    allocator: Allocator,
+
+    pub fn deinit(self: *ResolvedAddress) void {
+        self.allocator.free(self.addresses);
+    }
+};
+
+/// Resolve hostname to IP addresses
+pub fn resolve(allocator: Allocator, hostname: []const u8, port: u16) !ResolvedAddress {
+    var list: std.ArrayList(net.Address) = .{};
+    errdefer list.deinit(allocator);
+
+    const addrs = try net.getAddressList(allocator, hostname, port);
+    defer addrs.deinit();
+
+    for (addrs.addrs) |addr| {
+        try list.append(allocator, addr);
+    }
+
+    return .{
+        .addresses = try list.toOwnedSlice(allocator),
+        .allocator = allocator,
+    };
+}
+
+// ============================================================================
+// Connection state tracking
+// ============================================================================
+
+pub const ConnectionState = enum {
+    disconnected,
+    connecting,
+    connected,
+    tls_handshaking,
+    tls_established,
+    closing,
+    closed,
+    error_state,
+};
+
+/// Connection info for diagnostics
+pub const ConnectionInfo = struct {
+    local_address: ?Address = null,
+    remote_address: ?Address = null,
+    state: ConnectionState = .disconnected,
+    bytes_sent: u64 = 0,
+    bytes_received: u64 = 0,
+    connect_time_ms: ?u64 = null,
+    last_activity_time: ?i64 = null,
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "Address parsing" {
+    const addr = try Address.parseIp4("127.0.0.1", 443);
+    try testing.expectEqual(@as(u16, 443), addr.getPort());
+}
+
+test "Address IPv6 parsing" {
+    const addr = try Address.parseIp6("::1", 8080);
+    try testing.expectEqual(@as(u16, 8080), addr.getPort());
+}

--- a/src/mayaqua/network/socks.zig
+++ b/src/mayaqua/network/socks.zig
@@ -1,0 +1,358 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const testing = std.testing;
+const net = std.net;
+const posix = std.posix;
+
+const socket = @import("socket.zig");
+const TcpSocket = socket.TcpSocket;
+
+pub const SocksError = error{
+    ConnectionFailed,
+    RequestRejected,
+    RequestFailed,
+    IdentdFailed,
+    InvalidResponse,
+    AuthMethodRejected,
+    AuthFailed,
+    UnsupportedAddressType,
+    UnsupportedVersion,
+    HostUnreachable,
+    ConnectionRefused,
+    TtlExpired,
+    CommandNotSupported,
+    AddressTypeNotSupported,
+    NetworkUnreachable,
+    NotAllowed,
+    GeneralFailure,
+};
+
+pub const Socks4ResponseStatus = enum(u8) {
+    granted = 0x5A,
+    rejected = 0x5B,
+    identd_failed = 0x5C,
+    identd_mismatch = 0x5D,
+};
+
+pub const Socks5AuthMethod = enum(u8) {
+    no_auth = 0x00,
+    gssapi = 0x01,
+    username_password = 0x02,
+    no_acceptable = 0xFF,
+};
+
+pub const Socks5Reply = enum(u8) {
+    succeeded = 0x00,
+    general_failure = 0x01,
+    not_allowed = 0x02,
+    network_unreachable = 0x03,
+    host_unreachable = 0x04,
+    connection_refused = 0x05,
+    ttl_expired = 0x06,
+    command_not_supported = 0x07,
+    address_type_not_supported = 0x08,
+};
+
+pub const AddressType = enum(u8) {
+    ipv4 = 0x01,
+    domain = 0x03,
+    ipv6 = 0x04,
+};
+
+pub const ProxyConfig = struct {
+    host: []const u8,
+    port: u16,
+    username: ?[]const u8 = null,
+    password: ?[]const u8 = null,
+};
+
+pub fn connectViaSocks4(
+    allocator: Allocator,
+    proxy: ProxyConfig,
+    target_host: []const u8,
+    target_port: u16,
+) !TcpSocket {
+    var tcp = try TcpSocket.connectHost(proxy.host, proxy.port, 30000);
+    errdefer tcp.close();
+
+    const target_ip = resolveToIpv4(target_host) catch {
+        tcp.close();
+        return SocksError.HostUnreachable;
+    };
+
+    var req: [9]u8 = undefined;
+    req[0] = 4; // version
+    req[1] = 1; // CONNECT
+    req[2] = @as(u8, @intCast(target_port >> 8));
+    req[3] = @as(u8, @intCast(target_port & 0xFF));
+    req[4..8].* = target_ip;
+
+    const user_id = proxy.username orelse "";
+    const full_req = try std.mem.concat(allocator, u8, &[_][]const u8{ &req, user_id, &[_]u8{0} });
+    defer allocator.free(full_req);
+
+    try tcp.writeAll(full_req);
+
+    var resp: [8]u8 = undefined;
+    try tcp.readAll(resp[0..]);
+    if (resp[0] != 0x00) return SocksError.InvalidResponse;
+
+    switch (resp[1]) {
+        0x5A => return tcp,
+        0x5B => return SocksError.RequestRejected,
+        0x5C => return SocksError.IdentdFailed,
+        0x5D => return SocksError.IdentdFailed,
+        else => return SocksError.RequestRejected,
+    }
+}
+
+pub fn connectViaSocks5(
+    allocator: Allocator,
+    proxy: ProxyConfig,
+    target_host: []const u8,
+    target_port: u16,
+) !TcpSocket {
+    _ = allocator;
+    var tcp = try TcpSocket.connectHost(proxy.host, proxy.port, 30000);
+    errdefer tcp.close();
+
+    try socks5Auth(&tcp, proxy);
+
+    try socks5Connect(&tcp, target_host, target_port);
+
+    return tcp;
+}
+
+fn socks5Auth(tcp: *TcpSocket, proxy: ProxyConfig) !void {
+    const has_auth = proxy.username != null and proxy.password != null;
+
+    var methods_buf: [4]u8 = undefined;
+    methods_buf[0] = 5; // version
+    if (has_auth) {
+        methods_buf[1] = 2; // nmethods
+        methods_buf[2] = 0x02; // username/password
+        methods_buf[3] = 0x00; // no auth
+        try tcp.writeAll(methods_buf[0..4]);
+    } else {
+        methods_buf[1] = 1; // nmethods
+        methods_buf[2] = 0x00; // no auth
+        try tcp.writeAll(methods_buf[0..3]);
+    }
+
+    var method_resp: [2]u8 = undefined;
+    try tcp.readAll(method_resp[0..]);
+    if (method_resp[0] != 5) return SocksError.UnsupportedVersion;
+
+    if (method_resp[1] == 0xFF) return SocksError.AuthMethodRejected;
+
+    if (method_resp[1] == 0x02 and has_auth) {
+        try socks5UserPassAuth(tcp, proxy.username.?, proxy.password.?);
+    }
+}
+
+fn socks5UserPassAuth(tcp: *TcpSocket, username: []const u8, password: []const u8) !void {
+    if (username.len > 255 or password.len > 255) return SocksError.AuthFailed;
+
+    var auth_buf: [513]u8 = undefined;
+    var off: usize = 0;
+    auth_buf[off] = 1;
+    off += 1; // version
+    auth_buf[off] = @as(u8, @intCast(username.len));
+    off += 1;
+    for (username, 0..) |b, i| auth_buf[off + i] = b;
+    off += username.len;
+    auth_buf[off] = @as(u8, @intCast(password.len));
+    off += 1;
+    for (password, 0..) |b, i| auth_buf[off + i] = b;
+    off += password.len;
+
+    try tcp.writeAll(auth_buf[0..off]);
+
+    var resp: [2]u8 = undefined;
+    try tcp.readAll(resp[0..]);
+    if (resp[0] != 1) return SocksError.UnsupportedVersion;
+    if (resp[1] != 0) return SocksError.AuthFailed;
+}
+
+fn socks5Connect(tcp: *TcpSocket, host: []const u8, port: u16) !void {
+    var req_buf: [262]u8 = undefined;
+    var off: usize = 0;
+
+    req_buf[off] = 5;
+    off += 1; // version
+    req_buf[off] = 1;
+    off += 1; // CONNECT
+    req_buf[off] = 0;
+    off += 1; // reserved
+
+    if (net.Address.parseIp4(host, 0)) |addr| {
+        req_buf[off] = @intFromEnum(AddressType.ipv4);
+        off += 1;
+        const ip4_bytes = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
+        for (ip4_bytes, 0..) |b, i| req_buf[off + i] = b;
+        off += 4;
+    } else |_| {
+        if (net.Address.parseIp6(host, 0)) |addr| {
+            req_buf[off] = @intFromEnum(AddressType.ipv6);
+            off += 1;
+            for (&addr.in6.sa.addr, 0..) |b, i| req_buf[off + i] = b;
+            off += 16;
+        } else |_| {
+            if (host.len > 255) return SocksError.UnsupportedAddressType;
+            req_buf[off] = @intFromEnum(AddressType.domain);
+            off += 1;
+            req_buf[off] = @as(u8, @intCast(host.len));
+            off += 1;
+            for (host, 0..) |b, i| req_buf[off + i] = b;
+            off += host.len;
+        }
+    }
+
+    req_buf[off] = @as(u8, @intCast(port >> 8));
+    off += 1;
+    req_buf[off] = @as(u8, @intCast(port & 0xFF));
+    off += 1;
+
+    try tcp.writeAll(req_buf[0..off]);
+
+    var resp: [4]u8 = undefined;
+    try tcp.readAll(resp[0..]);
+    if (resp[0] != 5) return SocksError.UnsupportedVersion;
+    if (resp[1] != 0) {
+        return switch (resp[1]) {
+            0x01 => SocksError.GeneralFailure,
+            0x02 => SocksError.NotAllowed,
+            0x03 => SocksError.NetworkUnreachable,
+            0x04 => SocksError.HostUnreachable,
+            0x05 => SocksError.ConnectionRefused,
+            0x06 => SocksError.TtlExpired,
+            0x07 => SocksError.CommandNotSupported,
+            0x08 => SocksError.AddressTypeNotSupported,
+            else => SocksError.RequestRejected,
+        };
+    }
+
+    switch (resp[3]) {
+        @intFromEnum(AddressType.ipv4) => {
+            var addr_buf: [4]u8 = undefined;
+            try tcp.readAll(addr_buf[0..]);
+            var port_buf: [2]u8 = undefined;
+            try tcp.readAll(port_buf[0..]);
+        },
+        @intFromEnum(AddressType.domain) => {
+            var len_buf: [1]u8 = undefined;
+            try tcp.readAll(len_buf[0..]);
+            const domain_buf = try std.heap.page_allocator.alloc(u8, len_buf[0]);
+            defer std.heap.page_allocator.free(domain_buf);
+            try tcp.readAll(domain_buf);
+            var port_buf: [2]u8 = undefined;
+            try tcp.readAll(port_buf[0..]);
+        },
+        @intFromEnum(AddressType.ipv6) => {
+            var addr_buf: [16]u8 = undefined;
+            try tcp.readAll(addr_buf[0..]);
+            var port_buf: [2]u8 = undefined;
+            try tcp.readAll(port_buf[0..]);
+        },
+        else => return SocksError.UnsupportedAddressType,
+    }
+}
+
+fn resolveToIpv4(host: []const u8) ![4]u8 {
+    // Parse dotted-decimal IPv4 string directly.
+    // net.Address.parseIp4 exists but extracting raw bytes from it in a
+    // platform-independent way is fragile (sockaddr layout differs per OS).
+    var result: [4]u8 = .{0} ** 4;
+    var octet_idx: usize = 0;
+    var start: usize = 0;
+    while (start < host.len and octet_idx < 4) {
+        const end = std.mem.indexOfScalarPos(u8, host, start, '.') orelse host.len;
+        const octet = std.fmt.parseInt(u8, host[start..end], 10) catch return SocksError.HostUnreachable;
+        result[octet_idx] = octet;
+        octet_idx += 1;
+        start = end + 1;
+    }
+    if (octet_idx != 4) return SocksError.HostUnreachable;
+    return result;
+}
+
+test "SOCKS4 request format" {
+    var buf: [9]u8 = undefined;
+    buf[0] = 4;
+    buf[1] = 1;
+    const port: u16 = 443;
+    buf[2] = @as(u8, @intCast(port >> 8));
+    buf[3] = @as(u8, @intCast(port & 0xFF));
+    buf[4..8].* = .{ 10, 0, 0, 1 };
+    buf[8] = 0;
+
+    try testing.expectEqual(@as(u8, 4), buf[0]);
+    try testing.expectEqual(@as(u8, 1), buf[1]);
+    try testing.expectEqual(@as(u8, 0x01), buf[2]);
+    try testing.expectEqual(@as(u8, 0xBB), buf[3]);
+    try testing.expectEqual(@as(u8, 10), buf[4]);
+}
+
+test "SOCKS4 response status parsing" {
+    try testing.expectEqual(@as(u8, 0x5A), @intFromEnum(Socks4ResponseStatus.granted));
+    try testing.expectEqual(@as(u8, 0x5B), @intFromEnum(Socks4ResponseStatus.rejected));
+}
+
+test "SOCKS5 auth method values" {
+    try testing.expectEqual(@as(u8, 0x00), @intFromEnum(Socks5AuthMethod.no_auth));
+    try testing.expectEqual(@as(u8, 0x02), @intFromEnum(Socks5AuthMethod.username_password));
+    try testing.expectEqual(@as(u8, 0xFF), @intFromEnum(Socks5AuthMethod.no_acceptable));
+}
+
+test "AddressType values" {
+    try testing.expectEqual(@as(u8, 0x01), @intFromEnum(AddressType.ipv4));
+    try testing.expectEqual(@as(u8, 0x03), @intFromEnum(AddressType.domain));
+    try testing.expectEqual(@as(u8, 0x04), @intFromEnum(AddressType.ipv6));
+}
+
+test "resolveToIpv4 parses IP string" {
+    const ip = try resolveToIpv4("10.0.0.1");
+    try testing.expectEqual(@as(u8, 10), ip[0]);
+    try testing.expectEqual(@as(u8, 0), ip[1]);
+    try testing.expectEqual(@as(u8, 0), ip[2]);
+    try testing.expectEqual(@as(u8, 1), ip[3]);
+}
+
+test "resolveToIpv4 returns error for hostname" {
+    try testing.expectError(SocksError.HostUnreachable, resolveToIpv4("example.com"));
+}
+
+test "SOCKS5 IPv6 address type encoding" {
+    var req_buf: [262]u8 = undefined;
+    var off: usize = 0;
+
+    req_buf[off] = 5;
+    off += 1;
+    req_buf[off] = 1;
+    off += 1;
+    req_buf[off] = 0;
+    off += 1;
+    req_buf[off] = @intFromEnum(AddressType.ipv6);
+    off += 1;
+
+    const ipv6_bytes = [_]u8{ 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
+    for (&ipv6_bytes, 0..) |b, i| req_buf[off + i] = b;
+    off += 16;
+
+    const port: u16 = 443;
+    req_buf[off] = @as(u8, @intCast(port >> 8));
+    off += 1;
+    req_buf[off] = @as(u8, @intCast(port & 0xFF));
+    off += 1;
+
+    try testing.expectEqual(@as(u8, 5), req_buf[0]);
+    try testing.expectEqual(@as(u8, 1), req_buf[1]);
+    try testing.expectEqual(@as(u8, 0x04), req_buf[3]);
+    try testing.expectEqual(@as(u8, 0x20), req_buf[4]);
+    try testing.expectEqual(@as(u8, 0x01), req_buf[5]);
+    try testing.expectEqual(@as(u8, 0x0d), req_buf[6]);
+    try testing.expectEqual(@as(u8, 0xb8), req_buf[7]);
+    try testing.expectEqual(@as(u8, 0x01), req_buf[19]);
+    try testing.expectEqual(@as(u8, 0x01), req_buf[20]);
+    try testing.expectEqual(@as(u8, 0xBB), req_buf[21]);
+}

--- a/src/mayaqua/network/tls.zig
+++ b/src/mayaqua/network/tls.zig
@@ -1,0 +1,949 @@
+//! TLS Module
+//!
+//! TLS wrapper for SoftEther VPN connections using OpenSSL.
+//! OpenSSL is required because SoftEther VPN servers typically use self-signed
+//! certificates, and we need fine-grained control over certificate verification.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const net = std.net;
+const c = @cImport({
+    @cInclude("openssl/ssl.h");
+    @cInclude("openssl/err.h");
+    @cInclude("openssl/x509.h");
+});
+const Allocator = std.mem.Allocator;
+
+/// Network interface index to bind outbound TLS sockets to (Darwin IP_BOUND_IF /
+/// IPV6_BOUND_IF). Set via softether_set_bind_interface() in ffi.zig. Required on
+/// iOS NEPacketTunnelProvider so the extension's own outbound connection bypasses
+/// the tunnel that's about to be established. Zero = no binding.
+pub var bind_interface_index: c_uint = 0;
+
+/// Optional host-provided TCP dial function. When set, libsoftether's TLS connect
+/// path skips DNS+POSIX-connect and instead asks the host for a connected fd.
+/// Required on iOS NEPacketTunnelProvider where NECP denies the extension's own
+/// connect() — Swift dials via NEProvider.createTCPConnection (outside the
+/// tunnel) and bridges bytes through a socketpair. Zero/null = use POSIX path.
+pub const ExternalTcpDialFn = *const fn (host: [*:0]const u8, port: u16) callconv(.c) c_int;
+pub var external_tcp_dial: ?ExternalTcpDialFn = null;
+
+/// Darwin socket option constants (sys/socket.h). Not in std.posix on iOS.
+const DARWIN_IP_BOUND_IF: c_int = 25;
+const DARWIN_IPV6_BOUND_IF: c_int = 125;
+const DARWIN_IPPROTO_IP: c_int = 0;
+const DARWIN_IPPROTO_IPV6: c_int = 41;
+const testing = std.testing;
+
+const socket_mod = @import("socket.zig");
+const TcpSocket = socket_mod.TcpSocket;
+const dns_cache_mod = @import("dns_cache.zig");
+const http_mod = @import("http.zig");
+const route_heal = @import("../../adapter/route_heal.zig");
+
+/// Proxy configuration for TLS connect. Re-exported for convenience.
+pub const ProxyConfig = http_mod.ProxyConfig;
+
+/// Global DNS cache instance for TLS connections
+var global_dns_cache: ?dns_cache_mod.DnsCache = null;
+var dns_cache_init_mutex: std.Thread.Mutex = .{};
+
+/// Get or initialize the global DNS cache
+fn getDnsCache(allocator: Allocator) *dns_cache_mod.DnsCache {
+    dns_cache_init_mutex.lock();
+    defer dns_cache_init_mutex.unlock();
+
+    if (global_dns_cache == null) {
+        global_dns_cache = dns_cache_mod.DnsCache.init(allocator, null);
+    }
+    return &global_dns_cache.?;
+}
+
+/// TLS errors
+pub const TlsError = error{
+    HandshakeFailed,
+    CertificateVerificationFailed,
+    CertificateExpired,
+    CertificateRevoked,
+    HostnameMismatch,
+    UnsupportedProtocol,
+    AlertReceived,
+    RecordOverflow,
+    BadCertificate,
+    InternalError,
+    TlsInitializationFailed,
+    ConnectionClosed,
+    ConnectionFailed,
+    OutOfMemory,
+};
+
+/// TLS version
+pub const TlsVersion = enum {
+    tls_1_2,
+    tls_1_3,
+};
+
+/// TLS configuration
+pub const TlsConfig = struct {
+    /// Verify server certificate (should be true in production)
+    verify_certificate: bool = true,
+
+    /// Minimum TLS version
+    min_version: TlsVersion = .tls_1_2,
+
+    /// Connection timeout in milliseconds
+    timeout_ms: u32 = 30000,
+
+    /// SoftEther-specific: Accept self-signed certificates
+    /// WARNING: Only use for testing or when server cert is pinned
+    allow_self_signed: bool = false,
+
+    /// Client certificate PEM data (for certificate authentication)
+    client_cert_pem: ?[]const u8 = null,
+
+    /// Client private key PEM data (for certificate authentication)
+    client_key_pem: ?[]const u8 = null,
+
+    /// SNI hostname override. When set, this is used for the TLS SNI extension
+    /// instead of the hostname passed to connect(). Required on cluster-redirect
+    /// where the TCP connection goes to an IP literal but the load balancer needs
+    /// the original server hostname to route the TLS handshake.
+    sni_hostname: ?[]const u8 = null,
+
+    /// Proxy configuration. When set, the TCP connection is established through
+    /// the proxy before the TLS handshake. Supports HTTP CONNECT, SOCKS4, SOCKS5.
+    proxy: ?ProxyConfig = null,
+};
+
+/// TCP connect with configurable timeout using non-blocking socket + poll.
+/// Avoids the OS default 75s SYN timeout that causes apparent freezes.
+fn tcpConnectWithTimeout(address: net.Address, timeout_ms: u32) !std.posix.socket_t {
+    const fd = try std.posix.socket(address.any.family, std.posix.SOCK.STREAM, 0);
+    errdefer {
+        if (builtin.os.tag == .windows) {
+            _ = std.os.windows.ws2_32.closesocket(fd);
+        } else {
+            std.posix.close(fd);
+        }
+    }
+
+    // Darwin: bind socket to specific interface BEFORE connect(). Required on iOS
+    // NEPacketTunnelProvider extensions, otherwise the kernel's NECP layer routes
+    // the extension's outbound socket through the (not-yet-established) tunnel
+    // and we get instant ECONNREFUSED.
+    if ((builtin.os.tag == .ios or builtin.os.tag == .macos) and bind_interface_index != 0) {
+        const idx_bytes = std.mem.asBytes(&bind_interface_index);
+        if (address.any.family == std.posix.AF.INET6) {
+            std.posix.setsockopt(fd, DARWIN_IPPROTO_IPV6, DARWIN_IPV6_BOUND_IF, idx_bytes) catch |err| {
+                std.log.warn("TLS: IPV6_BOUND_IF(idx={d}) failed: {}", .{ bind_interface_index, err });
+            };
+        } else {
+            std.posix.setsockopt(fd, DARWIN_IPPROTO_IP, DARWIN_IP_BOUND_IF, idx_bytes) catch |err| {
+                std.log.warn("TLS: IP_BOUND_IF(idx={d}) failed: {}", .{ bind_interface_index, err });
+            };
+        }
+    }
+
+    if (builtin.os.tag == .windows) {
+        // Windows: use ioctlsocket for non-blocking mode
+        const ws2 = std.os.windows.ws2_32;
+        var nonblocking: c_ulong = 1;
+        _ = ws2.ioctlsocket(fd, @as(i32, @bitCast(@as(u32, 0x8004667e))), &nonblocking); // FIONBIO
+
+        // Initiate connect
+        std.posix.connect(fd, &address.any, address.getOsSockLen()) catch |err| switch (err) {
+            error.WouldBlock => {},
+            else => return err,
+        };
+
+        // Poll for write-readiness
+        var poll_fds = [1]std.posix.pollfd{
+            .{ .fd = fd, .events = std.posix.POLL.OUT, .revents = 0 },
+        };
+        const effective_timeout: i32 = if (timeout_ms > 0) @intCast(timeout_ms) else 30000;
+        const poll_result = try std.posix.poll(&poll_fds, effective_timeout);
+        if (poll_result == 0) {
+            return error.ConnectionTimedOut;
+        }
+
+        // Check for connect error via revents
+        if (poll_fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.HUP) != 0) {
+            std.log.err("TLS: TCP connect failed (poll revents={x})", .{poll_fds[0].revents});
+            return error.ConnectionRefused;
+        }
+
+        // Restore blocking mode
+        nonblocking = 0;
+        _ = ws2.ioctlsocket(fd, @as(i32, @bitCast(@as(u32, 0x8004667e))), &nonblocking); // FIONBIO
+    } else {
+        // POSIX: use fcntl for non-blocking mode
+        // O_NONBLOCK differs per OS: macOS/BSD = 0x0004, Linux/Android = 0x0800
+        const O_NONBLOCK: usize = if (builtin.os.tag == .linux) 0x0800 else 0x0004;
+        const flags = try std.posix.fcntl(fd, std.posix.F.GETFL, 0);
+        _ = try std.posix.fcntl(fd, std.posix.F.SETFL, flags | O_NONBLOCK);
+
+        // Initiate connect — returns immediately with WouldBlock (EINPROGRESS)
+        std.posix.connect(fd, &address.any, address.getOsSockLen()) catch |err| switch (err) {
+            error.WouldBlock => {},
+            else => return err,
+        };
+
+        // Poll for write-readiness (connection completion)
+        var poll_fds = [1]std.posix.pollfd{
+            .{ .fd = fd, .events = std.posix.POLL.OUT, .revents = 0 },
+        };
+        const effective_timeout: i32 = if (timeout_ms > 0) @intCast(timeout_ms) else 30000;
+        const poll_result = try std.posix.poll(&poll_fds, effective_timeout);
+        if (poll_result == 0) {
+            return error.ConnectionTimedOut;
+        }
+
+        // Check for connect error via SO_ERROR
+        var so_error: c_int = 0;
+        var optlen: std.posix.socklen_t = @sizeOf(c_int);
+        const rc = std.c.getsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.ERROR, @ptrCast(&so_error), &optlen);
+        if (rc != 0) {
+            return error.ConnectionRefused;
+        }
+        if (so_error != 0) {
+            return error.ConnectionRefused;
+        }
+
+        // Restore blocking mode
+        _ = try std.posix.fcntl(fd, std.posix.F.SETFL, flags);
+    }
+
+    return fd;
+}
+
+/// Emit a contextual error message for a TCP connect failure. For the
+/// generic case this is just the error tag; for `AddressNotAvailable` on
+/// Darwin/Linux this expands into a stale-route diagnosis with the exact
+/// `route delete` command the operator should run.
+///
+/// Background: a previous VPN session that crashed or was kill -9'd leaves
+/// behind a host route to the server pointing through a now-defunct utunN
+/// interface. When the kernel resolves the destination, it picks the dead
+/// interface, can't bind a source address, and returns EADDRNOTAVAIL — even
+/// though the destination is otherwise reachable (verifiable with `nc -vz`).
+fn logConnectError(err: anyerror, hostname: []const u8, port: u16) void {
+    if (err == error.AddressNotAvailable) {
+        std.log.err(
+            "TLS: TCP connect to {s}:{d} failed with AddressNotAvailable. " ++
+                "This is almost always a stale host route from a previous VPN session " ++
+                "(usually pointing through a now-defunct utunN interface). " ++
+                "Recover with:  sudo route -n delete {s}  — then retry.",
+            .{ hostname, port, hostname },
+        );
+    } else {
+        std.log.err("TLS: TCP connect to {s}:{d} failed: {}", .{ hostname, port, err });
+    }
+}
+
+/// TLS-wrapped socket using OpenSSL
+pub const TlsSocket = struct {
+    allocator: Allocator,
+    tcp_fd: std.posix.socket_t,
+    ssl_ctx: ?*c.SSL_CTX,
+    ssl: ?*c.SSL,
+    config: TlsConfig,
+    hostname_buf: []u8,
+    connected: bool,
+    /// Counter incremented every time writeAllNonBlocking polls POLLOUT (i.e.
+    /// the underlying TCP sndbuf was full). Surfaced via DIAG to detect
+    /// TX-bound bufferbloat.
+    write_block_count: u64 = 0,
+
+    /// Connect to hostname:port with TLS
+    pub fn connect(allocator: Allocator, hostname: []const u8, port: u16, config: TlsConfig) !TlsSocket {
+        // Initialize OpenSSL (idempotent in modern OpenSSL)
+        _ = c.OPENSSL_init_ssl(0, null);
+
+        // Resolve and connect TCP
+        var tcp_fd: std.posix.socket_t = undefined;
+
+        // iOS NEPacketTunnelProvider escape hatch: when the host (Swift) has
+        // registered a dial callback, delegate the TCP connection to it. This
+        // bypasses NECP, which denies the extension's own POSIX connect().
+        // The host returns one end of a socketpair connected to its
+        // NWTCPConnection; OpenSSL runs TLS over the UNIX socket.
+        var via_host_dial: bool = false;
+        if (external_tcp_dial) |dial| {
+            const c_host = try allocator.dupeZ(u8, hostname);
+            defer allocator.free(c_host);
+            std.log.info("TLS: dialing {s}:{d} via host callback", .{ hostname, port });
+            const fd_int = dial(c_host.ptr, port);
+            if (fd_int < 0) {
+                std.log.err("TLS: host dial callback returned {d} for {s}:{d}", .{ fd_int, hostname, port });
+                return TlsError.ConnectionFailed;
+            }
+            // Windows: socket_t is an opaque *SOCKET pointer; reconstruct from the integer fd.
+            // Other platforms: socket_t is an integer.
+            tcp_fd = if (builtin.os.tag == .windows)
+                @ptrFromInt(@as(usize, @intCast(fd_int)))
+            else
+                @intCast(fd_int);
+            via_host_dial = true;
+        } else if (config.proxy) |proxy| {
+            // Proxy connect: delegate TCP establishment to the proxy (HTTP CONNECT,
+            // SOCKS4, or SOCKS5). TLS is layered on top as usual.
+            var proxy_sock = try http_mod.connectViaProxy(allocator, proxy, hostname, port);
+            errdefer proxy_sock.close();
+            tcp_fd = proxy_sock.stream.handle;
+        } else
+        // First try to parse as IP address
+        if (net.Address.resolveIp(hostname, port)) |address| {
+            std.log.debug("TLS: Resolved IP address directly: {s}:{d}", .{ hostname, port });
+            const connect_result = tcpConnectWithTimeout(address, config.timeout_ms);
+            if (connect_result) |fd| {
+                tcp_fd = fd;
+            } else |err| {
+                // #9: Auto-repair stale host route on EADDRNOTAVAIL, then retry once
+                if (err == error.AddressNotAvailable and
+                    route_heal.repairStaleHostRoute(allocator, hostname, port))
+                {
+                    std.log.info("TLS: Retrying {s}:{d} after stale-route repair", .{ hostname, port });
+                    tcp_fd = tcpConnectWithTimeout(address, config.timeout_ms) catch |retry_err| {
+                        logConnectError(retry_err, hostname, port);
+                        return TlsError.ConnectionFailed;
+                    };
+                } else {
+                    logConnectError(err, hostname, port);
+                    return TlsError.ConnectionFailed;
+                }
+            }
+        } else |resolve_err| {
+            std.log.debug("TLS: Not an IP, trying DNS for: {s} (err: {})", .{ hostname, resolve_err });
+
+            // Try DNS cache first, fall back to OS resolution
+            const cache = getDnsCache(allocator);
+            const cached_addrs = cache.resolveWithCache(hostname, port) catch |err| {
+                std.log.err("TLS: DNS resolution failed: {}", .{err});
+                return TlsError.ConnectionFailed;
+            };
+
+            if (cached_addrs.len == 0) {
+                std.log.err("TLS: No addresses found for {s}", .{hostname});
+                return TlsError.ConnectionFailed;
+            }
+
+            // Iterate ALL DNS results (RFC 6724 / "Happy Eyeballs"-lite). On iOS the
+            // system resolver typically returns AAAA before A; if the server has no
+            // IPv6 listener (or the path RSTs) we get instant ECONNREFUSED on the
+            // first result and must fall through to the next address. Without this
+            // loop the iOS NEPacketTunnel extension fails to connect even though
+            // macOS/Android happen to work because their first result is reachable.
+            var last_err: anyerror = error.ConnectionRefused;
+            var connected_idx: ?usize = null;
+            for (cached_addrs, 0..) |addr, i| {
+                const result = tcpConnectWithTimeout(addr, config.timeout_ms);
+                if (result) |fd| {
+                    tcp_fd = fd;
+                    connected_idx = i;
+                    break;
+                } else |err| {
+                    std.log.warn("TLS: TCP connect to DNS result #{d} failed: {} (trying next)", .{ i, err });
+                    last_err = err;
+                }
+            }
+            if (connected_idx == null) {
+                cache.invalidate(hostname);
+                std.log.err("TLS: All {d} DNS results failed for {s}, last err: {}", .{ cached_addrs.len, hostname, last_err });
+                // #9: Auto-repair stale host route on EADDRNOTAVAIL, then retry once
+                if (last_err == error.AddressNotAvailable and
+                    route_heal.repairStaleHostRoute(allocator, hostname, port))
+                {
+                    std.log.info("TLS: Retrying {s}:{d} after stale-route repair", .{ hostname, port });
+                    for (cached_addrs, 0..) |addr, retry_i| {
+                        const retry_result = tcpConnectWithTimeout(addr, config.timeout_ms);
+                        if (retry_result) |fd| {
+                            tcp_fd = fd;
+                            connected_idx = retry_i;
+                            break;
+                        } else |retry_err| {
+                            std.log.warn("TLS: Retry #{d} failed: {}", .{ retry_i, retry_err });
+                        }
+                    }
+                    if (connected_idx == null) {
+                        logConnectError(last_err, hostname, port);
+                        return TlsError.ConnectionFailed;
+                    }
+                } else {
+                    if (last_err == error.AddressNotAvailable) {
+                        logConnectError(last_err, hostname, port);
+                    }
+                    return TlsError.ConnectionFailed;
+                }
+            }
+        }
+        errdefer {
+            if (builtin.os.tag == .windows) {
+                _ = std.os.windows.ws2_32.closesocket(tcp_fd);
+            } else {
+                std.posix.close(tcp_fd);
+            }
+        }
+
+        // CRITICAL: Disable Nagle's algorithm for low latency.
+        // Skip on host-dialed sockets (AF_UNIX socketpair from iOS NEPacketTunnel
+        // bridge) — TCP_NODELAY is invalid on AF_UNIX (returns ENOPROTOOPT) and
+        // Nagle is handled by NWTCPConnection on the host side.
+        if (!via_host_dial) {
+            const nodelay: u32 = 1;
+            const IPPROTO_TCP = 6;
+            const TCP_NODELAY = 1;
+            std.posix.setsockopt(tcp_fd, IPPROTO_TCP, TCP_NODELAY, std.mem.asBytes(&nodelay)) catch |err| {
+                std.log.warn("Failed to set TCP_NODELAY: {}", .{err});
+            };
+        }
+
+        // CYCLE 11 (TURN 16b): TCP_NOTSENT_LOWAT REMOVED — see clearTimeouts() comment.
+        // Bufferbloat is bounded by SO_SNDBUF=512KB cap (set in clearTimeouts post-handshake).
+
+        // On Windows, disable delayed ACKs — default 200ms ACK delay adds latency
+        if (builtin.os.tag == .windows) {
+            const SIO_TCP_SET_ACK_FREQUENCY = @as(u32, 0x98000017);
+            var ack_freq: u32 = 1; // ACK every packet immediately
+            var bytes_returned: u32 = 0;
+            _ = std.os.windows.ws2_32.WSAIoctl(
+                tcp_fd,
+                SIO_TCP_SET_ACK_FREQUENCY,
+                @ptrCast(&ack_freq),
+                @sizeOf(u32),
+                null,
+                0,
+                &bytes_returned,
+                null,
+                null,
+            );
+        }
+
+        // Apply timeout
+        if (config.timeout_ms > 0) {
+            TcpSocket.setReadTimeout(tcp_fd, config.timeout_ms) catch {};
+            TcpSocket.setWriteTimeout(tcp_fd, config.timeout_ms) catch {};
+        }
+
+        // Allocate hostname buffer
+        const hostname_buf = try allocator.dupe(u8, hostname);
+        errdefer allocator.free(hostname_buf);
+
+        // Create SSL context
+        const method = c.TLS_client_method();
+        const ssl_ctx = c.SSL_CTX_new(method) orelse {
+            std.log.err("Failed to create SSL context", .{});
+            return TlsError.TlsInitializationFailed;
+        };
+        errdefer c.SSL_CTX_free(ssl_ctx);
+
+        // For SoftEther with self-signed certs, disable verification
+        if (config.allow_self_signed or !config.verify_certificate) {
+            c.SSL_CTX_set_verify(ssl_ctx, c.SSL_VERIFY_NONE, null);
+        }
+
+        // Load client certificate for certificate authentication
+        if (config.client_cert_pem) |cert_pem| {
+            const cert_bio = c.BIO_new_mem_buf(cert_pem.ptr, @intCast(cert_pem.len)) orelse {
+                std.log.err("TLS: Failed to create BIO for client certificate", .{});
+                return TlsError.TlsInitializationFailed;
+            };
+            defer _ = c.BIO_free(cert_bio);
+            const cert = c.PEM_read_bio_X509(cert_bio, null, null, null) orelse {
+                std.log.err("TLS: Failed to parse client certificate PEM", .{});
+                return TlsError.BadCertificate;
+            };
+            defer c.X509_free(cert);
+            if (c.SSL_CTX_use_certificate(ssl_ctx, cert) != 1) {
+                std.log.err("TLS: Failed to set client certificate", .{});
+                logOpenSslErrors();
+                return TlsError.BadCertificate;
+            }
+            std.log.info("TLS: Client certificate loaded", .{});
+        }
+
+        // Load client private key for certificate authentication
+        if (config.client_key_pem) |key_pem| {
+            const key_bio = c.BIO_new_mem_buf(key_pem.ptr, @intCast(key_pem.len)) orelse {
+                std.log.err("TLS: Failed to create BIO for client key", .{});
+                return TlsError.TlsInitializationFailed;
+            };
+            defer _ = c.BIO_free(key_bio);
+            const pkey = c.PEM_read_bio_PrivateKey(key_bio, null, null, null) orelse {
+                std.log.err("TLS: Failed to parse client private key PEM", .{});
+                return TlsError.BadCertificate;
+            };
+            defer c.EVP_PKEY_free(pkey);
+            if (c.SSL_CTX_use_PrivateKey(ssl_ctx, pkey) != 1) {
+                std.log.err("TLS: Failed to set client private key", .{});
+                logOpenSslErrors();
+                return TlsError.BadCertificate;
+            }
+            // Verify cert/key match
+            if (c.SSL_CTX_check_private_key(ssl_ctx) != 1) {
+                std.log.err("TLS: Client certificate and private key do not match", .{});
+                logOpenSslErrors();
+                return TlsError.BadCertificate;
+            }
+            std.log.info("TLS: Client private key loaded and verified", .{});
+        }
+
+        // Create SSL connection
+        const ssl = c.SSL_new(ssl_ctx) orelse {
+            std.log.err("Failed to create SSL object", .{});
+            return TlsError.TlsInitializationFailed;
+        };
+        errdefer c.SSL_free(ssl);
+
+        // Set hostname for SNI. On a cluster redirect the TCP connection goes
+        // to an IP literal but the load balancer may need the original server
+        // hostname to route the TLS handshake; config.sni_hostname lets the
+        // caller override what is sent in the SNI extension.
+        const sni_name = config.sni_hostname orelse hostname;
+        const hostname_z = try allocator.dupeZ(u8, sni_name);
+        defer allocator.free(hostname_z);
+        _ = c.SSL_set_tlsext_host_name(ssl, hostname_z.ptr);
+
+        // Attach to socket
+        const fd_int: c_int = if (builtin.os.tag == .windows) @intCast(@intFromPtr(tcp_fd)) else @intCast(tcp_fd);
+        if (c.SSL_set_fd(ssl, fd_int) != 1) {
+            std.log.err("Failed to set SSL fd", .{});
+            return TlsError.TlsInitializationFailed;
+        }
+
+        // Perform TLS handshake with retry loop for WANT_READ/WANT_WRITE
+        // (defensive: blocking sockets can still return these in edge cases on Android)
+        const fd_for_poll: std.posix.socket_t = tcp_fd;
+        var attempts: u32 = 0;
+        const max_attempts: u32 = 100;
+        while (true) : (attempts += 1) {
+            if (attempts >= max_attempts) {
+                std.log.err("TLS handshake failed: exceeded max retries", .{});
+                return TlsError.HandshakeFailed;
+            }
+            const ret = c.SSL_connect(ssl);
+            if (ret == 1) break;
+            const err = c.SSL_get_error(ssl, ret);
+            switch (err) {
+                c.SSL_ERROR_WANT_READ => {
+                    var pfd = [1]std.posix.pollfd{.{ .fd = fd_for_poll, .events = std.posix.POLL.IN, .revents = 0 }};
+                    const pr = std.posix.poll(&pfd, 30000) catch 0;
+                    if (pr == 0) {
+                        std.log.err("TLS handshake failed: timeout waiting for read", .{});
+                        return TlsError.HandshakeFailed;
+                    }
+                    continue;
+                },
+                c.SSL_ERROR_WANT_WRITE => {
+                    var pfd = [1]std.posix.pollfd{.{ .fd = fd_for_poll, .events = std.posix.POLL.OUT, .revents = 0 }};
+                    const pr = std.posix.poll(&pfd, 30000) catch 0;
+                    if (pr == 0) {
+                        std.log.err("TLS handshake failed: timeout waiting for write", .{});
+                        return TlsError.HandshakeFailed;
+                    }
+                    continue;
+                },
+                else => {
+                    std.log.err("TLS handshake failed: SSL error {d} (ret={d}, errno={d})", .{ err, ret, std.c._errno().* });
+                    logOpenSslErrors();
+                    return TlsError.HandshakeFailed;
+                },
+            }
+        }
+
+        // Log connection info
+        const version = c.SSL_get_version(ssl);
+        if (version) |v| {
+            std.log.info("TLS connected with {s}", .{std.mem.span(v)});
+        }
+
+        return TlsSocket{
+            .allocator = allocator,
+            .tcp_fd = tcp_fd,
+            .ssl_ctx = ssl_ctx,
+            .ssl = ssl,
+            .config = config,
+            .hostname_buf = hostname_buf,
+            .connected = true,
+        };
+    }
+
+    fn logOpenSslErrors() void {
+        var err = c.ERR_get_error();
+        while (err != 0) {
+            var buf: [256]u8 = undefined;
+            c.ERR_error_string_n(err, &buf, buf.len);
+            std.log.err("OpenSSL: {s}", .{std.mem.sliceTo(&buf, 0)});
+            err = c.ERR_get_error();
+        }
+    }
+
+    /// Close the connection
+    pub fn close(self: *TlsSocket) void {
+        if (self.connected) {
+            if (self.ssl) |ssl| {
+                _ = c.SSL_shutdown(ssl);
+                c.SSL_free(ssl);
+            }
+            if (self.ssl_ctx) |ctx| {
+                c.SSL_CTX_free(ctx);
+            }
+            if (builtin.os.tag == .windows) {
+                _ = std.os.windows.ws2_32.closesocket(self.tcp_fd);
+            } else {
+                std.posix.close(self.tcp_fd);
+            }
+            self.connected = false;
+            self.ssl = null;
+            self.ssl_ctx = null;
+        }
+
+        self.allocator.free(self.hostname_buf);
+    }
+
+    /// Read data from the TLS connection.
+    ///
+    /// Semantics:
+    ///   N > 0          : received N bytes
+    ///   0              : peer closed gracefully (TLS close_notify)
+    ///   error.WouldBlock : non-blocking socket has no data right now (caller retry)
+    ///   error.BrokenPipe : hard TLS / TCP error; connection lost
+    ///
+    /// On a blocking socket, WouldBlock should not occur. After calling
+    /// setNonBlocking() (data plane), callers MUST handle WouldBlock as a
+    /// normal "no data yet" signal, not an error.
+    pub fn read(self: *TlsSocket, buffer: []u8) !usize {
+        if (!self.connected) return error.BrokenPipe;
+
+        const ssl = self.ssl orelse return error.BrokenPipe;
+        const ret = c.SSL_read(ssl, buffer.ptr, @intCast(buffer.len));
+
+        if (ret <= 0) {
+            const err = c.SSL_get_error(ssl, ret);
+            switch (err) {
+                c.SSL_ERROR_ZERO_RETURN => {
+                    self.connected = false;
+                    return 0;
+                },
+                c.SSL_ERROR_WANT_READ, c.SSL_ERROR_WANT_WRITE => {
+                    // Non-blocking socket: nothing available right now.
+                    return error.WouldBlock;
+                },
+                else => {
+                    std.log.err("TlsSocket.read: SSL_get_error={d} ret={d} errno={d}", .{ err, ret, std.c._errno().* });
+                    logOpenSslErrors();
+                    self.connected = false;
+                    return error.BrokenPipe;
+                },
+            }
+        }
+
+        return @intCast(ret);
+    }
+
+    /// Read with built-in poll-on-WouldBlock retry, for control-plane use
+    /// where the caller expects classical blocking semantics regardless of
+    /// the underlying socket mode. Returns 0 only on graceful TLS close.
+    pub fn readBlocking(self: *TlsSocket, buffer: []u8) !usize {
+        while (true) {
+            const n = self.read(buffer) catch |err| switch (err) {
+                error.WouldBlock => {
+                    var pfd = [_]std.posix.pollfd{.{
+                        .fd = self.tcp_fd,
+                        .events = std.posix.POLL.IN,
+                        .revents = 0,
+                    }};
+                    const pr = std.posix.poll(&pfd, 30000) catch 0;
+                    if (pr == 0) return error.BrokenPipe;
+                    continue;
+                },
+                else => return err,
+            };
+            return n;
+        }
+    }
+
+    /// Read exactly n bytes
+    pub fn readAll(self: *TlsSocket, buffer: []u8) !void {
+        var index: usize = 0;
+        while (index < buffer.len) {
+            const n = try self.read(buffer[index..]);
+            if (n == 0) return error.EndOfStream;
+            index += n;
+        }
+    }
+
+    /// Check if OpenSSL has buffered decrypted application data invisible to poll().
+    /// SSL records may contain multiple application messages; SSL_read can leave
+    /// some buffered in the SSL object even when the kernel TCP buffer is empty
+    /// (poll() will report POLL.IN unset). Without this check the data loop
+    /// sleeps in poll while the next batch of bytes is already decrypted and
+    /// waiting — a major source of stalls under bursty inbound traffic.
+    pub fn hasPending(self: *TlsSocket) bool {
+        const ssl = self.ssl orelse return false;
+        return c.SSL_pending(ssl) > 0;
+    }
+
+    /// DIAGNOSTIC: Returns count of decrypted bytes buffered inside OpenSSL.
+    pub fn pendingBytes(self: *const TlsSocket) u32 {
+        const ssl = self.ssl orelse return 0;
+        const p = c.SSL_pending(ssl);
+        return if (p > 0) @intCast(p) else 0;
+    }
+
+    /// DIAGNOSTIC (macOS): Returns bytes currently sitting in the kernel TCP
+    /// recv queue (i.e. arrived from network but not yet read by us). High
+    /// values mean we're not draining fast enough → server's advertised
+    /// window is shrinking → TCP backpressure.
+    pub fn kernelRecvQueue(self: *const TlsSocket) u32 {
+        if (comptime builtin.os.tag != .macos) return 0;
+        var n: c_int = 0;
+        var len: u32 = @sizeOf(c_int);
+        // SO_NREAD = 0x1020 on macOS/Darwin
+        const SO_NREAD: u32 = 0x1020;
+        const fd_int: c_int = @intCast(self.tcp_fd);
+        const rc = std.c.getsockopt(fd_int, std.posix.SOL.SOCKET, SO_NREAD, &n, &len);
+        if (rc != 0 or n < 0) return 0;
+        return @intCast(n);
+    }
+
+    /// DIAGNOSTIC (macOS): Returns bytes currently sitting in the kernel TCP
+    /// send queue (queued but not yet ACK'd / sent). High values mean we
+    /// can't push outbound fast enough → our send window is full → upload
+    /// backpressure / risk of SSL_write deadlock.
+    pub fn kernelSendQueue(self: *const TlsSocket) u32 {
+        if (comptime builtin.os.tag != .macos) return 0;
+        var n: c_int = 0;
+        var len: u32 = @sizeOf(c_int);
+        // SO_NWRITE = 0x1024 on macOS/Darwin
+        const SO_NWRITE: u32 = 0x1024;
+        const fd_int: c_int = @intCast(self.tcp_fd);
+        const rc = std.c.getsockopt(fd_int, std.posix.SOL.SOCKET, SO_NWRITE, &n, &len);
+        if (rc != 0 or n < 0) return 0;
+        return @intCast(n);
+    }
+
+    /// Write data to the TLS connection.
+    ///
+    /// Semantics:
+    ///   N > 0          : wrote N bytes
+    ///   0              : caller-supplied empty buffer
+    ///   error.WouldBlock : non-blocking socket cannot accept data right now
+    ///   error.BrokenPipe : hard TLS / TCP error; connection lost
+    pub fn write(self: *TlsSocket, data: []const u8) !usize {
+        if (!self.connected) return error.BrokenPipe;
+
+        const ssl = self.ssl orelse return error.BrokenPipe;
+        const ret = c.SSL_write(ssl, data.ptr, @intCast(data.len));
+
+        if (ret <= 0) {
+            const err = c.SSL_get_error(ssl, ret);
+            switch (err) {
+                c.SSL_ERROR_WANT_READ, c.SSL_ERROR_WANT_WRITE => {
+                    return error.WouldBlock;
+                },
+                else => {
+                    self.connected = false;
+                    return error.BrokenPipe;
+                },
+            }
+        }
+
+        return @intCast(ret);
+    }
+
+    /// Write with poll-based waiting (avoids busy spin)
+    pub fn writeWithPoll(self: *TlsSocket, data: []const u8) !usize {
+        if (!self.connected) return error.BrokenPipe;
+
+        const ssl = self.ssl orelse return error.BrokenPipe;
+        const ret = c.SSL_write(ssl, data.ptr, @intCast(data.len));
+
+        if (ret <= 0) {
+            const err = c.SSL_get_error(ssl, ret);
+            switch (err) {
+                c.SSL_ERROR_WANT_WRITE => {
+                    // Wait for socket to be writable (max 1ms to avoid blocking too long)
+                    var pfd = [_]std.posix.pollfd{.{
+                        .fd = self.tcp_fd,
+                        .events = std.posix.POLL.OUT,
+                        .revents = 0,
+                    }};
+                    _ = std.posix.poll(&pfd, 1) catch {};
+                    return 0;
+                },
+                c.SSL_ERROR_WANT_READ => {
+                    return 0;
+                },
+                else => {
+                    self.connected = false;
+                    return error.BrokenPipe;
+                },
+            }
+        }
+
+        return @intCast(ret);
+    }
+
+    /// Write all data, polling for socket writability when the kernel
+    /// send buffer is full. Safe on a non-blocking socket: WouldBlock from
+    /// SSL_write triggers a short poll(POLLOUT) wait and retry with the
+    /// SAME data pointer (required by OpenSSL non-blocking write semantics).
+    ///
+    /// Used by the data-plane writer adapter so the per-packet sendBlocks
+    /// path remains effectively atomic from the caller's perspective even
+    /// after the socket is switched to non-blocking mode.
+    pub fn writeAllNonBlocking(self: *TlsSocket, data: []const u8) !void {
+        var index: usize = 0;
+        while (index < data.len) {
+            const n = self.write(data[index..]) catch |err| switch (err) {
+                error.WouldBlock => {
+                    self.write_block_count +%= 1;
+                    var pfd = [_]std.posix.pollfd{.{
+                        .fd = self.tcp_fd,
+                        .events = std.posix.POLL.OUT,
+                        .revents = 0,
+                    }};
+                    // 1ms poll — enough for kernel to drain some sndbuf bytes
+                    // without stalling the data loop long enough to cause
+                    // ACK starvation. 50ms was causing the retrans-storm
+                    // cascade by freezing inbound processing for too long.
+                    _ = std.posix.poll(&pfd, 1) catch {};
+                    continue;
+                },
+                else => return err,
+            };
+            if (n == 0) return error.BrokenPipe;
+            index += n;
+        }
+    }
+
+    /// Switch the underlying TCP socket to non-blocking mode.
+    /// Call this AFTER the TLS handshake has completed and BEFORE entering
+    /// the data-plane poll loop. Once non-blocking:
+    ///   - read()  returns error.WouldBlock when no data is available
+    ///   - write() returns error.WouldBlock when kernel sndbuf is full
+    /// Use writeAllNonBlocking() for sends that must complete atomically.
+    pub fn setNonBlocking(self: *TlsSocket) !void {
+        if (builtin.os.tag == .windows) {
+            const ws2 = std.os.windows.ws2_32;
+            var nonblocking: c_ulong = 1;
+            _ = ws2.ioctlsocket(self.tcp_fd, @as(i32, @bitCast(@as(u32, 0x8004667e))), &nonblocking);
+        } else {
+            const O_NONBLOCK: usize = 0x0004;
+            const flags = try std.posix.fcntl(self.tcp_fd, std.posix.F.GETFL, 0);
+            _ = try std.posix.fcntl(self.tcp_fd, std.posix.F.SETFL, flags | O_NONBLOCK);
+        }
+    }
+
+    /// Write all data (blocking until complete)
+    pub fn writeAll(self: *TlsSocket, data: []const u8) !void {
+        var index: usize = 0;
+        while (index < data.len) {
+            const n = try self.write(data[index..]);
+            if (n == 0) continue;
+            index += n;
+        }
+    }
+
+    /// Check if connection is still alive
+    pub fn isConnected(self: *const TlsSocket) bool {
+        return self.connected;
+    }
+
+    /// Get the underlying socket
+    pub fn getFd(self: *const TlsSocket) std.posix.socket_t {
+        return self.tcp_fd;
+    }
+
+    /// Remove read/write timeouts set during connect phase and configure
+    /// socket for the poll-based data loop. Matches C SoftEther's
+    /// SetTimeout(sock, INFINITE) after connect.
+    ///
+    /// SO_SNDBUF policy:
+    ///   - NONE → macOS autotunes to multi-MB → DL ACKs queue behind UL data
+    ///     in TLS egress for 800-1400ms → server sees ACK loss → DL collapses
+    ///     to 5-7 Mbps with 1100ms RTT spikes (Cloudflare-confirmed).
+    ///   - 512KB cap (Cycle 10) → still queues ~50ms of DL ACKs; UL capped.
+    ///   - 128KB cap → bounds DL-ACK queueing latency to ~10ms at 100 Mbps
+    ///     egress while still allowing autotune RWND headroom on receive.
+    ///     This is the latency vs throughput tradeoff for single-thread
+    ///     poll-driven encap loop. Long-term fix is split-thread I/O.
+    /// SO_RCVBUF policy:
+    ///   - NONE → kernel autotune. In practice on macOS/iOS over TLS the
+    ///     advertised RWND grows VERY slowly because the read pattern is
+    ///     "drain-to-empty then idle" (we read everything ssl_pending says
+    ///     is there, then poll). Autotune sees small instantaneous queue
+    ///     depth (nread_max=8KB observed even mid-DL) and keeps RWND tiny.
+    ///     Server's BDP-bound send cap = RWND/RTT → 8KB/180ms ≈ 360 kbps.
+    ///     This explains DL stuck at 1-2 Mbps even though the loop is idle.
+    ///   - 4MB explicit → forces a large advertised RWND from the start.
+    ///     At 180ms RTT, BDP = 4MB → up to ~178 Mbps single-flow DL ceiling.
+    ///     Memory cost is bounded (one TLS conn → 4MB kernel rcvbuf).
+    pub fn clearTimeouts(self: *TlsSocket) void {
+        TcpSocket.setReadTimeout(self.tcp_fd, 0) catch {};
+        TcpSocket.setWriteTimeout(self.tcp_fd, 0) catch {};
+
+        // Enable TCP keepalive
+        const keepalive: u32 = 1;
+        std.posix.setsockopt(self.tcp_fd, std.posix.SOL.SOCKET, std.posix.SO.KEEPALIVE, std.mem.asBytes(&keepalive)) catch {};
+
+        // SO_SNDBUF sizing tradeoff at typical 180ms tunnel RTT:
+        //   Baseline 86 Mbps was achieved at 4MB (no cap, kernel autotune).
+        //   Caps ≤1MB cause sndbuf-full → SSL_write stalls for 50ms polling
+        //   POLLOUT → data loop can't process inbound during stall → ACK
+        //   starvation → server retransmits → inner cwnd collapse → retrans
+        //   storms on ALL platforms (macOS/Android/iOS). Cascade defeats
+        //   any latency benefit from a smaller buffer.
+        //   4MB → kernel doubles to ~8MB = 4× BDP at 86 Mbps/180ms RTT.
+        //   Sndbuf never fills in steady state; no stalls, no cascade.
+        //   Memory cost: 4MB per TLS connection (negligible).
+        const snd_cap: u32 = 2 * 1024 * 1024;
+        std.posix.setsockopt(self.tcp_fd, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, std.mem.asBytes(&snd_cap)) catch {};
+
+        // SO_RCVBUF: forces a large advertised RWND from the start so the
+        // server isn't BDP-capped by tiny autotune values.
+        //
+        // Platform-specific tuning:
+        //
+        // macOS (and Linux/desktop): 4 MB. Drain via utun fd is very fast
+        //   (100+ Mbps), so a big buffer just enables high-BDP flows. At
+        //   180ms RTT, 4MB → up to ~178 Mbps single-flow DL ceiling.
+        //
+        // iOS: 1 MB. Tradeoff calibrated empirically:
+        //   4 MB → DL 4.4 Mbps but ping_DL=2426ms (massive bufferbloat
+        //          in NEPacketTunnelFlow.writePackets opaque queue)
+        //   256 KB → DL 1.57 Mbps with ping_DL=1351ms (BDP cap too low,
+        //          single-flow throughput collapses)
+        //   1 MB → expected DL ~10-20 Mbps with ping_DL ~600-900ms
+        //          Single-flow BDP at 200ms RTT = 40 Mbps cap.
+        // The fundamental problem is writePackets has no completion API,
+        // so we can't true-backpressure. The outer rcvbuf is our only
+        // throttle on inbound rate. Cap = (rcvbuf / inner-RTT-no-bloat).
+        const rcv_cap: u32 = if (@import("builtin").target.os.tag == .ios) 1024 * 1024 else 4 * 1024 * 1024;
+        std.posix.setsockopt(self.tcp_fd, std.posix.SOL.SOCKET, std.posix.SO.RCVBUF, std.mem.asBytes(&rcv_cap)) catch {};
+    }
+
+    /// Get the hostname this socket connected to
+    pub fn getHostname(self: *const TlsSocket) []const u8 {
+        return self.hostname_buf;
+    }
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "TlsConfig defaults" {
+    const config = TlsConfig{};
+    try testing.expect(config.verify_certificate);
+    try testing.expectEqual(TlsVersion.tls_1_2, config.min_version);
+    try testing.expectEqual(@as(u32, 30000), config.timeout_ms);
+    try testing.expect(!config.allow_self_signed);
+}
+
+test "TlsSocket structure" {
+    // Test that the structure compiles correctly
+    // Actual connection tests require a server
+    const T = TlsSocket;
+    try testing.expect(@sizeOf(T) > 0);
+}

--- a/src/mayaqua/network/udp_accel.zig
+++ b/src/mayaqua/network/udp_accel.zig
@@ -22,7 +22,7 @@ const socket_mod = @import("socket.zig");
 const UdpSocket = socket_mod.UdpSocket;
 const Address = socket_mod.Address;
 
-const cipher_mod = @import("../mayaqua/encrypt/cipher.zig");
+const cipher_mod = @import("../encrypt/cipher.zig");
 const Aes128Cbc = cipher_mod.Aes128Cbc;
 const block_size = cipher_mod.block_size;
 


### PR DESCRIPTION
…mports

Create the Mayaqua platform abstraction module with encrypt, kernel, and network sub-systems mirroring the SoftEther C source hierarchy. Update all internal imports across the codebase to reference the new `mayaqua/` paths. Add the reorganization proposal document to guide future restructuring efforts.