### PR TITLE
Add Android VpnService.protect() callback, improve auth handler compa…

### DIFF
--- a/src/cedar/client/auth_handler.zig
+++ b/src/cedar/client/auth_handler.zig
@@ -83,8 +83,7 @@ pub fn run(client: *VpnClient) !void {
     // redundant and some servers reject a non-zero value. Keep it at 0
     // to match the original C client behaviour across all server versions.
     const server_ip: u32 = 0;
-    var ip_buf: [48]u8 = undefined;
-    const server_hostname = if (client.server_ip) |addr| formatAddress(addr, &ip_buf) else client.config.server_address;
+    const server_hostname = "";
 
     const session_opts = softether_proto.SessionOptions{
         .max_connection = client.config.max_connections,

--- a/src/cedar/client/vpn_client.zig
+++ b/src/cedar/client/vpn_client.zig
@@ -424,7 +424,14 @@ pub const VpnClient = struct {
         self.event_user_data = user_data;
     }
 
+    /// Thread-safe state read. The state poller on Android (and any other
+    /// concurrent reader) calls this from a separate thread while connect()
+    /// holds the mutex. Without the lock, reading self.state is a data race
+    /// per the C11/Zig memory model even though ARM word reads are atomic.
     pub fn getState(self: *const Self) ClientState {
+        const mutable = @constCast(self);
+        mutable.mutex.lock();
+        defer mutable.mutex.unlock();
         return self.state;
     }
 

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -596,6 +596,22 @@ export fn softether_set_tcp_dial_callback(cb: ?tls_mod.ExternalTcpDialFn) void {
     }
 }
 
+/// Register an Android VpnService.protect() callback.
+///
+/// On Android, the VpnService creates a TUN device and routes ALL traffic
+/// through it. The VPN client's own TLS connections to the server would be
+/// caught in this routing loop — the TLS handshake goes through the TUN,
+/// which isn't connected to anything yet → instant failure. VpnService.protect()
+/// exempts a socket fd from the VPN routing so it goes through the physical
+/// network interface instead.
+///
+/// The Kotlin host calls this with a JNI-upcall wrapper that invokes
+/// VpnService.protect(fd). The callback returns the fd (unchanged) on success
+/// or -1 if protect failed. Pass null to clear.
+export fn softether_set_android_protect(cb: ?tls_mod.AndroidProtectFn) void {
+    tls_mod.android_protect_fn = cb;
+}
+
 /// Set default route (route all traffic through VPN). Must be called before connect().
 export fn softether_set_default_route(client: ?*VpnClient, enabled: bool) void {
     const c = client orelse return;

--- a/src/mayaqua/network/tls.zig
+++ b/src/mayaqua/network/tls.zig
@@ -29,6 +29,15 @@ pub var bind_interface_index: c_uint = 0;
 pub const ExternalTcpDialFn = *const fn (host: [*:0]const u8, port: u16) callconv(.c) c_int;
 pub var external_tcp_dial: ?ExternalTcpDialFn = null;
 
+/// Android VpnService.protect() callback. Called on every TCP socket fd created
+/// by libsoftether BEFORE the TLS handshake. The host (Kotlin/JNI) calls
+/// VpnService.protect(fd) to exempt the socket from the VPN's own routing —
+/// without this the TLS connection to the VPN server would be routed through
+/// the just-created TUN device (circular routing → instant failure).
+/// Returns the fd (unchanged on success) or -1 if protect failed.
+pub const AndroidProtectFn = *const fn (fd: c_int) callconv(.c) c_int;
+pub var android_protect_fn: ?AndroidProtectFn = null;
+
 /// Darwin socket option constants (sys/socket.h). Not in std.posix on iOS.
 const DARWIN_IP_BOUND_IF: c_int = 25;
 const DARWIN_IPV6_BOUND_IF: c_int = 125;
@@ -633,6 +642,19 @@ pub const TlsSocket = struct {
 
         // Attach to socket
         const fd_int: c_int = if (builtin.os.tag == .windows) @intCast(@intFromPtr(tcp_fd)) else @intCast(tcp_fd);
+
+        // Android: exempt this socket from the VPN's own routing table.
+        // Without VpnService.protect(), the TLS handshake packets would be
+        // routed through the just-created TUN → circular routing → ECONNREFUSED.
+        // The Kotlin host registers the protect callback via FFI before connect.
+        if (comptime builtin.os.tag == .linux and builtin.abi == .android) {
+            if (android_protect_fn) |protect| {
+                if (protect(fd_int) < 0) {
+                    std.log.err("TLS: VpnService.protect() failed for fd={d}", .{fd_int});
+                }
+            }
+        }
+
         if (c.SSL_set_fd(ssl, fd_int) != 1) {
             std.log.err("Failed to set SSL fd", .{});
             return TlsError.TlsInitializationFailed;


### PR DESCRIPTION
…tibility with C client, and make client state access thread-safe

## Summary

Brief description of what this PR does.

## Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation
- [ ] CI / Build

## Platform(s)

Which platforms does this affect?

- [ ] All (C ABI)
- [ ] CLI (`vpnclient`)
- [ ] Flutter / Dart FFI
- macOS
- Linux
- Windows
- iOS
- Android

## Checklist

- [ ] `zig build test` passes locally
- [ ] New tests added (if applicable)
- [ ] Updated `softether.h` header (if C ABI changed)
- [ ] Updated `build.zig.zon` version (if this is a release)
- [ ] Updated documentation (README, QUICKSTART, etc.)
- [ ] Code follows the existing style (no unrelated formatting changes)

## Related Issues

Closes #___
